### PR TITLE
Update solarpanel.json

### DIFF
--- a/src/main/resources/data/electrodynamics/recipes/solarpanel.json
+++ b/src/main/resources/data/electrodynamics/recipes/solarpanel.json
@@ -16,7 +16,7 @@
 			"item": "electrodynamics:circuitbasic"
 		},
 		"i": {
-			"item": "minecraft:ingot_iron"
+			"item": "minecraft:iron_ingot"
 		},
 		"d": {
 			"item": "electrodynamics:dustcopper"


### PR DESCRIPTION
Tag for ingot in recipe was reversed from proper tag. This was to fix an error thrown in logs.