### PR TITLE
Fix Buggy fillItemCategory() in ItemRailgun

### DIFF
--- a/src/main/java/electrodynamics/common/item/gear/tools/electric/utils/ItemRailgun.java
+++ b/src/main/java/electrodynamics/common/item/gear/tools/electric/utils/ItemRailgun.java
@@ -48,7 +48,9 @@ public class ItemRailgun extends ItemElectric implements IItemTemperate {
 	public void fillItemCategory(CreativeModeTab group, NonNullList<ItemStack> items) {
 		super.fillItemCategory(group, items);
 		for (ItemStack stack : items) {
-			IItemTemperate.setTemperature(stack, 0);
+			if(stack.getItem() instanceof ItemRailgun) {
+				IItemTemperate.setTemperature(stack, 0);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/aurilisdev/Electrodynamics/issues/97 in 1.16; porting to later MC versions as well because it's weird behavior that has the potential to break other mods.