### PR TITLE
Fix crash caused by "itemproperty_size" missing or being set to 0

### DIFF
--- a/src/main/java/electrodynamics/prefab/properties/PropertyType.java
+++ b/src/main/java/electrodynamics/prefab/properties/PropertyType.java
@@ -269,6 +269,7 @@ public enum PropertyType {
 			break;
 		case InventoryItems:
 			int size = tag.getInt(prop.getName() + "_size");
+			if (size == 0) { size = ((NonNullList<ItemStack>)prop.get()).size(); }
 			NonNullList<ItemStack> toBeFilled = NonNullList.<ItemStack>withSize(size, ItemStack.EMPTY);
 			ContainerHelper.loadAllItems(tag, toBeFilled);
 			val = toBeFilled;

--- a/src/main/java/electrodynamics/prefab/properties/PropertyType.java
+++ b/src/main/java/electrodynamics/prefab/properties/PropertyType.java
@@ -269,7 +269,10 @@ public enum PropertyType {
 			break;
 		case InventoryItems:
 			int size = tag.getInt(prop.getName() + "_size");
-			if (size == 0) { size = ((NonNullList<ItemStack>)prop.get()).size(); }
+			if (size == 0) {
+				NonNullList<ItemStack> propVal = (NonNullList<ItemStack>) prop.get();
+				size = propVal != null ? propVal.size() : 0;
+			}
 			NonNullList<ItemStack> toBeFilled = NonNullList.<ItemStack>withSize(size, ItemStack.EMPTY);
 			ContainerHelper.loadAllItems(tag, toBeFilled);
 			val = toBeFilled;


### PR DESCRIPTION
This is rather temporary solution but for me it works well enough. That means it doesn't crash when trying to load map from 1.16.5. Command to recreate crash: `/setblock ~ ~ ~ electrodynamics:batterybox{Items:[]}`