### PR TITLE
fix memory issues

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 # Electrodynamics parameters
-electrodynamics_version=0.9.0-4
+electrodynamics_version=0.9.1-0
 electrodynamics_group=electrodynamics
 electrodynamics_name=Electrodynamics
 

--- a/src/generated/resources/assets/electrodynamics/blockstates/gaspipeuninsulatedcopper.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/gaspipeuninsulatedcopper.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/gaspipe/gaspipeuninsulatedcopperside"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/gaspipe/gaspipeuninsulatedcoppercenter"
-  },
-  "wire": {
-    "model": "electrodynamics:block/gaspipe/gaspipeuninsulatedcopperside"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/gaspipeuninsulatedcopper"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/gaspipeuninsulatedplastic.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/gaspipeuninsulatedplastic.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/gaspipe/gaspipeuninsulatedplasticside"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/gaspipe/gaspipeuninsulatedplasticcenter"
-  },
-  "wire": {
-    "model": "electrodynamics:block/gaspipe/gaspipeuninsulatedplasticside"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/gaspipeuninsulatedplastic"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/gaspipeuninsulatedsteel.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/gaspipeuninsulatedsteel.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/gaspipe/gaspipeuninsulatedsteelside"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/gaspipe/gaspipeuninsulatedsteelcenter"
-  },
-  "wire": {
-    "model": "electrodynamics:block/gaspipe/gaspipeuninsulatedsteelside"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/gaspipeuninsulatedsteel"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/logisticalmanager.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/logisticalmanager.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/logisticalmanager_inventory"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/logisticalmanager_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/logisticalmanager_inventory"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/logisticalmanager"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/pipecopper.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/pipecopper.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/pipe/pipecopper_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/pipe/pipecopper_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/pipe/pipecopper_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/pipecopper"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/pipesteel.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/pipesteel.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/pipe/pipesteel_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/pipe/pipesteel_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/pipe/pipesteel_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/pipesteel"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedcopperblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedcopperblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedcopperblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedcopperblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedcopperblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedcopperblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedcopperbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedcopperbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedcopperbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedcoppergreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedcoppergreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcoppergreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcoppergreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcoppergreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedcoppergreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedcopperred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedcopperred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedcopperred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedcopperwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedcopperwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedcopperwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedcopperyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedcopperyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedcopperyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedcopperyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedgoldblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedgoldblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedgoldblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedgoldblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedgoldblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedgoldblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedgoldbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedgoldbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedgoldbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedgoldgreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedgoldgreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldgreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldgreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldgreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedgoldgreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedgoldred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedgoldred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedgoldred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedgoldwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedgoldwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedgoldwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedgoldyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedgoldyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedgoldyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedgoldyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedironblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedironblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedironblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedironblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedironblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedironblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedironbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedironbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedironbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedirongreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedirongreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedirongreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedirongreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedirongreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedirongreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedironred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedironred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedironred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedironwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedironwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedironwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedironyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedironyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedironyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedironyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsilverblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsilverblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilverblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilverblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilverblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedsilverblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsilverblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsilverblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilverblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilverblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilverblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedsilverblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsilverbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsilverbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilverbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilverbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilverbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedsilverbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsilvergreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsilvergreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilvergreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilvergreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilvergreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedsilvergreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsilverred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsilverred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilverred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilverred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilverred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedsilverred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsilverwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsilverwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilverwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilverwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilverwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedsilverwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsilveryellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsilveryellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilveryellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilveryellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsilveryellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedsilveryellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsuperconductiveblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsuperconductiveblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedsuperconductiveblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsuperconductiveblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsuperconductiveblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedsuperconductiveblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsuperconductivebrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsuperconductivebrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivebrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivebrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivebrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedsuperconductivebrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsuperconductivegreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsuperconductivegreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivegreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivegreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivegreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedsuperconductivegreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsuperconductivered.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsuperconductivered.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivered_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivered_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivered_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedsuperconductivered"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsuperconductivewhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsuperconductivewhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivewhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivewhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivewhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedsuperconductivewhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsuperconductiveyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedsuperconductiveyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedsuperconductiveyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedtinblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedtinblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedtinblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedtinblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedtinblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedtinblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedtinbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedtinbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedtinbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedtingreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedtingreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtingreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtingreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtingreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedtingreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedtinred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedtinred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedtinred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedtinwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedtinwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedtinwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedtinyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireceramicinsulatedtinyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireceramicinsulatedtinyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireceramicinsulatedtinyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirecopper.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirecopper.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirecopper_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirecopper_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirecopper_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirecopper"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wiregold.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wiregold.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wiregold_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wiregold_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wiregold_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wiregold"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedcopperblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedcopperblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedcopperblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedcopperblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedcopperblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedcopperblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedcopperbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedcopperbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedcopperbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedcoppergreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedcoppergreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcoppergreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcoppergreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcoppergreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedcoppergreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedcopperred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedcopperred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedcopperred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedcopperwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedcopperwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedcopperwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedcopperyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedcopperyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedcopperyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedcopperyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedgoldblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedgoldblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedgoldblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedgoldblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedgoldblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedgoldblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedgoldbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedgoldbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedgoldbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedgoldgreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedgoldgreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldgreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldgreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldgreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedgoldgreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedgoldred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedgoldred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedgoldred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedgoldwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedgoldwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedgoldwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedgoldyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedgoldyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedgoldyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedgoldyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedironblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedironblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedironblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedironblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedironblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedironblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedironbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedironbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedironbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedirongreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedirongreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedirongreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedirongreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedirongreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedirongreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedironred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedironred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedironred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedironwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedironwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedironwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedironyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedironyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedironyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedironyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsilverblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsilverblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilverblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilverblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilverblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedsilverblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsilverblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsilverblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilverblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilverblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilverblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedsilverblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsilverbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsilverbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilverbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilverbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilverbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedsilverbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsilvergreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsilvergreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilvergreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilvergreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilvergreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedsilvergreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsilverred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsilverred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilverred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilverred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilverred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedsilverred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsilverwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsilverwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilverwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilverwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilverwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedsilverwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsilveryellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsilveryellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilveryellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilveryellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsilveryellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedsilveryellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsuperconductiveblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsuperconductiveblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedsuperconductiveblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsuperconductiveblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsuperconductiveblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedsuperconductiveblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsuperconductivebrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsuperconductivebrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivebrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivebrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivebrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedsuperconductivebrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsuperconductivegreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsuperconductivegreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivegreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivegreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivegreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedsuperconductivegreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsuperconductivered.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsuperconductivered.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivered_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivered_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivered_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedsuperconductivered"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsuperconductivewhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsuperconductivewhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivewhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivewhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivewhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedsuperconductivewhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsuperconductiveyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedsuperconductiveyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedsuperconductiveyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedtinblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedtinblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedtinblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedtinblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedtinblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedtinblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedtinbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedtinbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedtinbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedtingreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedtingreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtingreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtingreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtingreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedtingreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedtinred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedtinred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedtinred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedtinwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedtinwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedtinwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedtinyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirehighlyinsulatedtinyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirehighlyinsulatedtinyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirehighlyinsulatedtinyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedcopperblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedcopperblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedcopperblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedcopperblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedcopperblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedcopperblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedcopperbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedcopperbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedcopperbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedcoppergreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedcoppergreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedcoppergreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedcoppergreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedcoppergreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedcoppergreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedcopperred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedcopperred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedcopperred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedcopperwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedcopperwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedcopperwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedcopperyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedcopperyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedcopperyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedcopperyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedgoldblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedgoldblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedgoldblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedgoldblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedgoldblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedgoldblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedgoldbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedgoldbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedgoldbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedgoldgreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedgoldgreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldgreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldgreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldgreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedgoldgreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedgoldred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedgoldred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedgoldred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedgoldwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedgoldwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedgoldwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedgoldyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedgoldyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedgoldyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedgoldyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedironblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedironblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedironblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedironblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedironblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedironblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedironblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedironblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedironblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedironblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedironblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedironblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedironbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedironbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedironbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedironbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedironbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedironbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedirongreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedirongreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedirongreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedirongreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedirongreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedirongreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedironred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedironred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedironred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedironred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedironred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedironred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedironwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedironwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedironwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedironwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedironwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedironwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedironyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedironyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedironyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedironyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedironyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedironyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsilverblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsilverblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilverblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilverblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilverblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedsilverblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsilverblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsilverblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilverblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilverblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilverblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedsilverblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsilverbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsilverbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilverbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilverbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilverbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedsilverbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsilvergreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsilvergreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilvergreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilvergreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilvergreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedsilvergreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsilverred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsilverred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilverred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilverred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilverred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedsilverred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsilverwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsilverwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilverwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilverwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilverwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedsilverwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsilveryellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsilveryellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilveryellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilveryellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedsilveryellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedsilveryellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsuperconductiveblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsuperconductiveblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductiveblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductiveblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductiveblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedsuperconductiveblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsuperconductiveblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsuperconductiveblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductiveblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductiveblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductiveblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedsuperconductiveblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsuperconductivebrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsuperconductivebrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductivebrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductivebrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductivebrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedsuperconductivebrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsuperconductivegreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsuperconductivegreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductivegreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductivegreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductivegreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedsuperconductivegreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsuperconductivered.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsuperconductivered.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductivered_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductivered_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductivered_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedsuperconductivered"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsuperconductivewhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsuperconductivewhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductivewhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductivewhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductivewhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedsuperconductivewhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsuperconductiveyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedsuperconductiveyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductiveyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductiveyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedsuperconductiveyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedsuperconductiveyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedtinblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedtinblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedtinblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedtinblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedtinblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedtinblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedtinbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedtinbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedtinbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedtingreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedtingreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedtingreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedtingreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedtingreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedtingreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedtinred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedtinred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedtinred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedtinwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedtinwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedtinwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedtinyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireinsulatedtinyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireinsulatedtinyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireinsulatedtinyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wireiron.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wireiron.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wireiron_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wireiron_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wireiron_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wireiron"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticscopperblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticscopperblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticscopperblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticscopperblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticscopperblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticscopperblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticscopperbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticscopperbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticscopperbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticscoppergreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticscoppergreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticscoppergreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticscoppergreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticscoppergreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticscoppergreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticscopperred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticscopperred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticscopperred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticscopperwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticscopperwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticscopperwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticscopperyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticscopperyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticscopperyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticscopperyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsgoldblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsgoldblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticsgoldblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsgoldblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsgoldblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticsgoldblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsgoldbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsgoldbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticsgoldbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsgoldgreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsgoldgreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldgreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldgreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldgreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticsgoldgreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsgoldred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsgoldred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticsgoldred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsgoldwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsgoldwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticsgoldwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsgoldyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsgoldyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticsgoldyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticsgoldyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsironblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsironblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticsironblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticsironblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticsironblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticsironblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsironblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsironblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticsironblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticsironblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticsironblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticsironblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsironbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsironbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticsironbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticsironbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticsironbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticsironbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsirongreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsirongreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticsirongreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticsirongreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticsirongreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticsirongreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsironred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsironred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticsironred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticsironred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticsironred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticsironred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsironwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsironwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticsironwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticsironwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticsironwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticsironwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsironyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticsironyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticsironyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticsironyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticsironyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticsironyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssilverblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssilverblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticssilverblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticssilverblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticssilverblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticssilverblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssilverblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssilverblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticssilverblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticssilverblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticssilverblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticssilverblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssilverbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssilverbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticssilverbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticssilverbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticssilverbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticssilverbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssilvergreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssilvergreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticssilvergreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticssilvergreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticssilvergreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticssilvergreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssilverred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssilverred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticssilverred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticssilverred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticssilverred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticssilverred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssilverwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssilverwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticssilverwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticssilverwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticssilverwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticssilverwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssilveryellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssilveryellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticssilveryellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticssilveryellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticssilveryellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticssilveryellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssuperconductiveblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssuperconductiveblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductiveblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductiveblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductiveblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticssuperconductiveblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssuperconductiveblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssuperconductiveblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductiveblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductiveblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductiveblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticssuperconductiveblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssuperconductivebrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssuperconductivebrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductivebrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductivebrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductivebrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticssuperconductivebrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssuperconductivegreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssuperconductivegreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductivegreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductivegreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductivegreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticssuperconductivegreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssuperconductivered.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssuperconductivered.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductivered_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductivered_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductivered_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticssuperconductivered"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssuperconductivewhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssuperconductivewhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductivewhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductivewhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductivewhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticssuperconductivewhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssuperconductiveyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticssuperconductiveyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductiveyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductiveyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticssuperconductiveyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticssuperconductiveyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticstinblack.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticstinblack.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticstinblack_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticstinblack_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticstinblack_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticstinblack"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticstinblue.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticstinblue.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticstinblue_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticstinblue_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticstinblue_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticstinblue"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticstinbrown.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticstinbrown.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticstinbrown_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticstinbrown_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticstinbrown_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticstinbrown"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticstingreen.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticstingreen.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticstingreen_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticstingreen_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticstingreen_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticstingreen"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticstinred.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticstinred.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticstinred_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticstinred_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticstinred_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticstinred"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticstinwhite.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticstinwhite.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticstinwhite_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticstinwhite_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticstinwhite_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticstinwhite"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticstinyellow.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wirelogisticstinyellow.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wirelogisticstinyellow_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wirelogisticstinyellow_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wirelogisticstinyellow_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wirelogisticstinyellow"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wiresilver.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wiresilver.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wiresilver_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wiresilver_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wiresilver_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wiresilver"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wiresuperconductive.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wiresuperconductive.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wiresuperconductive_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wiresuperconductive_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wiresuperconductive_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wiresuperconductive"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/blockstates/wiretin.json
+++ b/src/generated/resources/assets/electrodynamics/blockstates/wiretin.json
@@ -1,12 +1,7 @@
 {
-  "inventory": {
-    "model": "electrodynamics:block/wire/wiretin_side"
-  },
-  "loader": "electrodynamics:electrodynamicscableloader",
-  "none": {
-    "model": "electrodynamics:block/wire/wiretin_none"
-  },
-  "wire": {
-    "model": "electrodynamics:block/wire/wiretin_side"
+  "variants": {
+    "": {
+      "model": "electrodynamics:block/wiretin"
+    }
   }
 }

--- a/src/generated/resources/assets/electrodynamics/models/block/gaspipeuninsulatedcopper.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/gaspipeuninsulatedcopper.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/gaspipe/gaspipeuninsulatedcopperside"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/gaspipe/gaspipeuninsulatedcoppercenter"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/gaspipe/gaspipeuninsulatedcopperside"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/gaspipeuninsulatedplastic.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/gaspipeuninsulatedplastic.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/gaspipe/gaspipeuninsulatedplasticside"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/gaspipe/gaspipeuninsulatedplasticcenter"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/gaspipe/gaspipeuninsulatedplasticside"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/gaspipeuninsulatedsteel.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/gaspipeuninsulatedsteel.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/gaspipe/gaspipeuninsulatedsteelside"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/gaspipe/gaspipeuninsulatedsteelcenter"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/gaspipe/gaspipeuninsulatedsteelside"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/logisticalmanager.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/logisticalmanager.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/logisticalmanager_inventory"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/logisticalmanager_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/logisticalmanager_inventory"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/pipecopper.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/pipecopper.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/pipe/pipecopper_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/pipe/pipecopper_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/pipe/pipecopper_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/pipesteel.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/pipesteel.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/pipe/pipesteel_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/pipe/pipesteel_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/pipe/pipesteel_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedcopperblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedcopperblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedcopperblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedcopperblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedcopperbrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedcopperbrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedcoppergreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedcoppergreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedcopperred_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedcopperred_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedcopperwhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedcopperwhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedcopperyellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedcopperyellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedgoldblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedgoldblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedgoldblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedgoldblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedgoldbrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedgoldbrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedgoldgreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedgoldgreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedgoldred_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedgoldred_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedgoldwhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedgoldwhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedgoldyellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedgoldyellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedironblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedironblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedironblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedironblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedironbrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedironbrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedirongreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedirongreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedironred_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedironred_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedironwhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedironwhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedironyellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedironyellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsilverblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsilverblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsilverblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsilverblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsilverbrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsilverbrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsilvergreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsilvergreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsilverred_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsilverred_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsilverwhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsilverwhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsilveryellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsilveryellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsuperconductiveblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsuperconductiveblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsuperconductiveblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsuperconductiveblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsuperconductivebrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsuperconductivebrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsuperconductivegreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsuperconductivegreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsuperconductivered_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsuperconductivered_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsuperconductivewhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsuperconductivewhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsuperconductiveyellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedsuperconductiveyellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedtinblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedtinblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedtinblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedtinblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedtinbrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedtinbrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedtingreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedtingreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedtinred_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedtinred_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedtinwhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedtinwhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedtinyellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireceramicinsulatedtinyellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/ceramicinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulationbase": "electrodynamics:block/wire/insulationceramic_base",
     "insulationcolor": "electrodynamics:block/wire/insulationceramic",

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirecopper_none.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirecopper_none.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/wire_none",
+  "render_type": "minecraft:cutout",
   "textures": {
     "conductor": "electrodynamics:block/wire/copper",
     "particle": "#conductor"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirecopper_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirecopper_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/wire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "conductor": "electrodynamics:block/wire/copper",
     "particle": "#conductor"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wiregold_none.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wiregold_none.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/wire_none",
+  "render_type": "minecraft:cutout",
   "textures": {
     "conductor": "electrodynamics:block/wire/gold",
     "particle": "#conductor"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wiregold_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wiregold_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/wire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "conductor": "electrodynamics:block/wire/gold",
     "particle": "#conductor"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedcopperblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedcopperblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedcopperblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedcopperblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedcopperbrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedcopperbrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedcoppergreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedcoppergreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedcopperred_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedcopperred_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedcopperwhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedcopperwhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedcopperyellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedcopperyellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedgoldblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedgoldblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedgoldblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedgoldblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedgoldbrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedgoldbrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedgoldgreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedgoldgreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedgoldred_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedgoldred_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedgoldwhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedgoldwhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedgoldyellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedgoldyellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedironblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedironblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedironblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedironblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedironbrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedironbrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedirongreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedirongreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedironred_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedironred_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedironwhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedironwhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedironyellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedironyellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsilverblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsilverblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsilverblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsilverblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsilverbrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsilverbrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsilvergreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsilvergreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsilverred_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsilverred_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsilverwhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsilverwhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsilveryellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsilveryellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsuperconductiveblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsuperconductiveblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsuperconductiveblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsuperconductiveblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsuperconductivebrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsuperconductivebrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsuperconductivegreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsuperconductivegreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsuperconductivered_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsuperconductivered_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsuperconductivewhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsuperconductivewhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsuperconductiveyellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedsuperconductiveyellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedtinblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedtinblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedtinblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedtinblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedtinbrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedtinbrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedtingreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedtingreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedtinred_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedtinred_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedtinwhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedtinwhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedtinyellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wirehighlyinsulatedtinyellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/highlyinsulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedcopperblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedcopperblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedcopperblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedcopperblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedcopperbrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedcopperbrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedcoppergreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedcoppergreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedcopperred_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedcopperred_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedcopperwhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedcopperwhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedcopperyellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedcopperyellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedgoldblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedgoldblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedgoldblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedgoldblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedgoldbrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedgoldbrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedgoldgreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedgoldgreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedgoldred_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedgoldred_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedgoldwhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedgoldwhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedgoldyellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedgoldyellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedironblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedironblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedironblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedironblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedironbrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedironbrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedirongreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedirongreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedironred_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedironred_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedironwhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedironwhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedironyellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedironyellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsilverblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsilverblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsilverblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsilverblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsilverbrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsilverbrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsilvergreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsilvergreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsilverred_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsilverred_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsilverwhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsilverwhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsilveryellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsilveryellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsuperconductiveblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsuperconductiveblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsuperconductiveblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsuperconductiveblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsuperconductivebrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsuperconductivebrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsuperconductivegreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsuperconductivegreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsuperconductivered_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsuperconductivered_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsuperconductivewhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsuperconductivewhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsuperconductiveyellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedsuperconductiveyellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedtinblack_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedtinblack_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedtinblue_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedtinblue_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedtinbrown_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedtinbrown_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedtingreen_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedtingreen_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedtinred_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedtinred_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedtinwhite_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedtinwhite_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedtinyellow_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireinsulatedtinyellow_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/insulatedwire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "insulation": "electrodynamics:block/wire/insulationwool",
     "particle": "#insulation"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireiron_none.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireiron_none.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/wire_none",
+  "render_type": "minecraft:cutout",
   "textures": {
     "conductor": "electrodynamics:block/wire/iron",
     "particle": "#conductor"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wireiron_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wireiron_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/wire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "conductor": "electrodynamics:block/wire/iron",
     "particle": "#conductor"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wiresilver_none.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wiresilver_none.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/wire_none",
+  "render_type": "minecraft:cutout",
   "textures": {
     "conductor": "electrodynamics:block/wire/silver",
     "particle": "#conductor"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wiresilver_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wiresilver_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/wire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "conductor": "electrodynamics:block/wire/silver",
     "particle": "#conductor"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wiresuperconductive_none.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wiresuperconductive_none.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/wire_none",
+  "render_type": "minecraft:cutout",
   "textures": {
     "conductor": "electrodynamics:block/wire/superconductive",
     "particle": "#conductor"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wiresuperconductive_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wiresuperconductive_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/wire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "conductor": "electrodynamics:block/wire/superconductive",
     "particle": "#conductor"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wiretin_none.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wiretin_none.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/wire_none",
+  "render_type": "minecraft:cutout",
   "textures": {
     "conductor": "electrodynamics:block/wire/tin",
     "particle": "#conductor"

--- a/src/generated/resources/assets/electrodynamics/models/block/wire/wiretin_side.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wire/wiretin_side.json
@@ -1,5 +1,6 @@
 {
   "parent": "electrodynamics:parent/wire_side",
+  "render_type": "minecraft:cutout",
   "textures": {
     "conductor": "electrodynamics:block/wire/tin",
     "particle": "#conductor"

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedcopperblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedcopperblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedcopperblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedcopperblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedcopperbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedcopperbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedcoppergreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedcoppergreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcoppergreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcoppergreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcoppergreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedcopperred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedcopperred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedcopperwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedcopperwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedcopperyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedcopperyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedcopperyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedgoldblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedgoldblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedgoldblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedgoldblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedgoldbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedgoldbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedgoldgreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedgoldgreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldgreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldgreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldgreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedgoldred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedgoldred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedgoldwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedgoldwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedgoldyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedgoldyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedgoldyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedironblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedironblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedironblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedironblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedironbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedironbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedirongreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedirongreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedirongreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedirongreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedirongreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedironred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedironred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedironwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedironwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedironyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedironyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedironyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsilverblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsilverblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilverblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilverblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilverblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsilverblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsilverblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilverblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilverblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilverblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsilverbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsilverbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilverbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilverbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilverbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsilvergreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsilvergreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilvergreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilvergreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilvergreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsilverred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsilverred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilverred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilverred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilverred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsilverwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsilverwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilverwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilverwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilverwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsilveryellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsilveryellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilveryellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilveryellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsilveryellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsuperconductiveblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsuperconductiveblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsuperconductiveblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsuperconductiveblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsuperconductivebrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsuperconductivebrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivebrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivebrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivebrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsuperconductivegreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsuperconductivegreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivegreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivegreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivegreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsuperconductivered.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsuperconductivered.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivered_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivered_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivered_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsuperconductivewhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsuperconductivewhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivewhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivewhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductivewhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsuperconductiveyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedsuperconductiveyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedsuperconductiveyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedtinblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedtinblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedtinblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedtinblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedtinbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedtinbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedtingreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedtingreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtingreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtingreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtingreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedtinred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedtinred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedtinwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedtinwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedtinyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireceramicinsulatedtinyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireceramicinsulatedtinyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirecopper.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirecopper.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirecopper_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirecopper_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirecopper_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wiregold.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wiregold.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wiregold_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wiregold_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wiregold_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedcopperblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedcopperblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedcopperblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedcopperblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedcopperbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedcopperbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedcoppergreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedcoppergreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcoppergreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcoppergreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcoppergreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedcopperred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedcopperred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedcopperwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedcopperwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedcopperyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedcopperyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedcopperyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedgoldblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedgoldblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedgoldblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedgoldblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedgoldbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedgoldbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedgoldgreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedgoldgreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldgreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldgreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldgreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedgoldred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedgoldred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedgoldwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedgoldwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedgoldyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedgoldyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedgoldyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedironblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedironblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedironblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedironblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedironbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedironbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedirongreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedirongreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedirongreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedirongreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedirongreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedironred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedironred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedironwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedironwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedironyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedironyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedironyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsilverblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsilverblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilverblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilverblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilverblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsilverblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsilverblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilverblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilverblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilverblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsilverbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsilverbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilverbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilverbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilverbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsilvergreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsilvergreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilvergreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilvergreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilvergreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsilverred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsilverred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilverred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilverred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilverred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsilverwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsilverwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilverwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilverwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilverwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsilveryellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsilveryellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilveryellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilveryellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsilveryellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsuperconductiveblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsuperconductiveblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsuperconductiveblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsuperconductiveblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsuperconductivebrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsuperconductivebrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivebrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivebrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivebrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsuperconductivegreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsuperconductivegreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivegreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivegreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivegreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsuperconductivered.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsuperconductivered.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivered_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivered_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivered_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsuperconductivewhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsuperconductivewhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivewhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivewhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductivewhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsuperconductiveyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedsuperconductiveyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedsuperconductiveyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedtinblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedtinblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedtinblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedtinblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedtinbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedtinbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedtingreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedtingreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtingreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtingreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtingreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedtinred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedtinred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedtinwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedtinwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedtinyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirehighlyinsulatedtinyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirehighlyinsulatedtinyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedcopperblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedcopperblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedcopperblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedcopperblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedcopperbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedcopperbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedcoppergreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedcoppergreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcoppergreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcoppergreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcoppergreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedcopperred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedcopperred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedcopperwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedcopperwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedcopperyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedcopperyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedcopperyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedgoldblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedgoldblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedgoldblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedgoldblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedgoldbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedgoldbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedgoldgreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedgoldgreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldgreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldgreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldgreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedgoldred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedgoldred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedgoldwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedgoldwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedgoldyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedgoldyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedgoldyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedironblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedironblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedironblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedironblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedironbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedironbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedirongreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedirongreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedirongreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedirongreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedirongreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedironred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedironred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedironwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedironwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedironyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedironyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedironyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsilverblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsilverblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilverblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilverblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilverblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsilverblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsilverblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilverblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilverblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilverblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsilverbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsilverbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilverbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilverbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilverbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsilvergreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsilvergreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilvergreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilvergreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilvergreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsilverred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsilverred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilverred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilverred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilverred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsilverwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsilverwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilverwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilverwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilverwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsilveryellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsilveryellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilveryellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilveryellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsilveryellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsuperconductiveblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsuperconductiveblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductiveblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductiveblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductiveblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsuperconductiveblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsuperconductiveblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductiveblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductiveblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductiveblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsuperconductivebrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsuperconductivebrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductivebrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductivebrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductivebrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsuperconductivegreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsuperconductivegreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductivegreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductivegreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductivegreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsuperconductivered.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsuperconductivered.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductivered_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductivered_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductivered_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsuperconductivewhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsuperconductivewhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductivewhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductivewhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductivewhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsuperconductiveyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedsuperconductiveyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductiveyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductiveyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedsuperconductiveyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedtinblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedtinblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedtinblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedtinblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedtinbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedtinbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedtingreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedtingreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtingreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtingreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtingreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedtinred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedtinred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedtinwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedtinwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedtinyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireinsulatedtinyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireinsulatedtinyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wireiron.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wireiron.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wireiron_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wireiron_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wireiron_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticscopperblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticscopperblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticscopperblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticscopperblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticscopperbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticscopperbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticscoppergreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticscoppergreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticscoppergreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticscoppergreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticscoppergreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticscopperred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticscopperred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticscopperwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticscopperwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticscopperyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticscopperyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticscopperyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsgoldblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsgoldblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsgoldblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsgoldblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsgoldbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsgoldbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsgoldgreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsgoldgreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldgreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldgreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldgreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsgoldred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsgoldred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsgoldwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsgoldwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsgoldyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsgoldyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticsgoldyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsironblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsironblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsironblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsironblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsironbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsironbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsirongreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsirongreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticsirongreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticsirongreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticsirongreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsironred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsironred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsironwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsironwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsironyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticsironyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticsironyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssilverblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssilverblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilverblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilverblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilverblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssilverblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssilverblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilverblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilverblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilverblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssilverbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssilverbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilverbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilverbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilverbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssilvergreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssilvergreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilvergreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilvergreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilvergreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssilverred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssilverred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilverred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilverred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilverred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssilverwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssilverwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilverwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilverwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilverwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssilveryellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssilveryellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilveryellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilveryellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticssilveryellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssuperconductiveblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssuperconductiveblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductiveblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductiveblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductiveblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssuperconductiveblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssuperconductiveblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductiveblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductiveblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductiveblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssuperconductivebrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssuperconductivebrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductivebrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductivebrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductivebrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssuperconductivegreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssuperconductivegreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductivegreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductivegreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductivegreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssuperconductivered.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssuperconductivered.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductivered_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductivered_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductivered_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssuperconductivewhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssuperconductivewhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductivewhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductivewhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductivewhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssuperconductiveyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticssuperconductiveyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductiveyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductiveyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticssuperconductiveyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticstinblack.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticstinblack.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinblack_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinblack_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinblack_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticstinblue.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticstinblue.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinblue_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinblue_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinblue_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticstinbrown.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticstinbrown.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinbrown_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinbrown_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinbrown_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticstingreen.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticstingreen.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticstingreen_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticstingreen_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticstingreen_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticstinred.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticstinred.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinred_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinred_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinred_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticstinwhite.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticstinwhite.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinwhite_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinwhite_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinwhite_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wirelogisticstinyellow.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wirelogisticstinyellow.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinyellow_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinyellow_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wirelogisticstinyellow_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wiresilver.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wiresilver.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wiresilver_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wiresilver_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wiresilver_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wiresuperconductive.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wiresuperconductive.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wiresuperconductive_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wiresuperconductive_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wiresuperconductive_side"
+  }
+}

--- a/src/generated/resources/assets/electrodynamics/models/block/wiretin.json
+++ b/src/generated/resources/assets/electrodynamics/models/block/wiretin.json
@@ -1,0 +1,14 @@
+{
+  "parent": "minecraft:block/cube",
+  "inventory": {
+    "parent": "electrodynamics:block/wire/wiretin_side"
+  },
+  "loader": "electrodynamics:electrodynamicscableloader",
+  "none": {
+    "parent": "electrodynamics:block/wire/wiretin_none"
+  },
+  "render_type": "minecraft:cutout",
+  "wire": {
+    "parent": "electrodynamics:block/wire/wiretin_side"
+  }
+}

--- a/src/main/java/electrodynamics/client/modelbakers/bakerypes/CableModelLoader.java
+++ b/src/main/java/electrodynamics/client/modelbakers/bakerypes/CableModelLoader.java
@@ -15,7 +15,7 @@ import com.google.gson.JsonParseException;
 import electrodynamics.client.modelbakers.ModelStateRotation;
 import electrodynamics.client.modelbakers.modelproperties.ModelPropertyConnections;
 import electrodynamics.common.block.connect.util.EnumConnectType;
-import electrodynamics.prefab.tile.types.GenericConnectTile;
+import electrodynamics.prefab.tile.types.IConnectTile;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.BlockModel;
@@ -33,6 +33,7 @@ import net.minecraft.util.GsonHelper;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.client.ChunkRenderTypeSet;
 import net.minecraftforge.client.model.IDynamicBakedModel;
 import net.minecraftforge.client.model.data.ModelData;
 import net.minecraftforge.client.model.geometry.IGeometryBakingContext;
@@ -40,13 +41,14 @@ import net.minecraftforge.client.model.geometry.IGeometryLoader;
 import net.minecraftforge.client.model.geometry.IUnbakedGeometry;
 
 public class CableModelLoader implements IGeometryLoader<CableModelLoader.WirePartGeometry> {
-	
+
 	public static final String ID = "electrodynamicscableloader";
 
 	public static final CableModelLoader INSTANCE = new CableModelLoader();
 
 	@Override
 	public WirePartGeometry read(JsonObject json, JsonDeserializationContext context) throws JsonParseException {
+
 		BlockModel none = context.deserialize(GsonHelper.getAsJsonObject(json, EnumConnectType.NONE.toString()), BlockModel.class);
 		BlockModel wire = context.deserialize(GsonHelper.getAsJsonObject(json, EnumConnectType.WIRE.toString()), BlockModel.class);
 		BlockModel inventory = context.deserialize(GsonHelper.getAsJsonObject(json, EnumConnectType.INVENTORY.toString()), BlockModel.class);
@@ -63,6 +65,7 @@ public class CableModelLoader implements IGeometryLoader<CableModelLoader.WirePa
 			this.none = none;
 			this.wire = wire;
 			this.inventory = inventory;
+
 		}
 
 		@Override
@@ -104,6 +107,7 @@ public class CableModelLoader implements IGeometryLoader<CableModelLoader.WirePa
 		private final boolean isGui3d;
 		private final boolean isSideLit;
 		private final TextureAtlasSprite particle;
+		// render type for general model defined by this one
 		private final BakedModel none;
 		private final BakedModel[] wires;
 		private final BakedModel[] inventories;
@@ -149,6 +153,13 @@ public class CableModelLoader implements IGeometryLoader<CableModelLoader.WirePa
 		}
 
 		@Override
+		public ChunkRenderTypeSet getRenderTypes(@NotNull BlockState state, @NotNull RandomSource rand, @NotNull ModelData data) {
+
+			return none.getRenderTypes(state, rand, data);
+
+		}
+
+		@Override
 		public @NotNull List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, @NotNull RandomSource rand, @NotNull ModelData extraData, @Nullable RenderType renderType) {
 			EnumConnectType[] data = extraData.get(ModelPropertyConnections.INSTANCE);
 			if (data == null) {
@@ -186,7 +197,7 @@ public class CableModelLoader implements IGeometryLoader<CableModelLoader.WirePa
 
 		@Override
 		public @NotNull ModelData getModelData(@NotNull BlockAndTintGetter level, @NotNull BlockPos pos, @NotNull BlockState state, @NotNull ModelData modelData) {
-			if (level.getBlockEntity(pos) instanceof GenericConnectTile tile) {
+			if (level.getBlockEntity(pos) instanceof IConnectTile tile) {
 				return ModelData.builder().with(ModelPropertyConnections.INSTANCE, tile.readConnections()).build();
 			}
 			return modelData;

--- a/src/main/java/electrodynamics/client/modelbakers/bakerypes/CableModelLoader.java
+++ b/src/main/java/electrodynamics/client/modelbakers/bakerypes/CableModelLoader.java
@@ -47,9 +47,9 @@ public class CableModelLoader implements IGeometryLoader<CableModelLoader.WirePa
 
 	@Override
 	public WirePartGeometry read(JsonObject json, JsonDeserializationContext context) throws JsonParseException {
-		BlockModel none = context.deserialize(GsonHelper.getAsJsonArray(json, EnumConnectType.NONE.toString()), BlockModel.class);
-		BlockModel wire = context.deserialize(GsonHelper.getAsJsonArray(json, EnumConnectType.WIRE.toString()), BlockModel.class);
-		BlockModel inventory = context.deserialize(GsonHelper.getAsJsonArray(json, EnumConnectType.INVENTORY.toString()), BlockModel.class);
+		BlockModel none = context.deserialize(GsonHelper.getAsJsonObject(json, EnumConnectType.NONE.toString()), BlockModel.class);
+		BlockModel wire = context.deserialize(GsonHelper.getAsJsonObject(json, EnumConnectType.WIRE.toString()), BlockModel.class);
+		BlockModel inventory = context.deserialize(GsonHelper.getAsJsonObject(json, EnumConnectType.INVENTORY.toString()), BlockModel.class);
 		return new WirePartGeometry(none, wire, inventory);
 	}
 
@@ -181,7 +181,7 @@ public class CableModelLoader implements IGeometryLoader<CableModelLoader.WirePa
 				quads.addAll(this.none.getQuads(state, side, rand, extraData, renderType));
 			}
 
-			return null;
+			return quads;
 		}
 
 		@Override

--- a/src/main/java/electrodynamics/common/block/connect/BlockFluidPipe.java
+++ b/src/main/java/electrodynamics/common/block/connect/BlockFluidPipe.java
@@ -36,15 +36,18 @@ public class BlockFluidPipe extends AbstractRefreshingConnectBlock {
 	}
 
 	@Override
-	public BlockState refreshConnections(BlockState otherState, BlockEntity tile, BlockState state, Direction dir) {
-		GenericConnectTile connect = (GenericConnectTile) tile;
+	public BlockState refreshConnections(BlockState otherState, BlockEntity otherTile, BlockState state, BlockEntity thisTile, Direction dir) {
+		if(!(thisTile instanceof GenericConnectTile)) {
+			return state;
+		}
+		GenericConnectTile thisConnect = (GenericConnectTile) thisTile;
 		EnumConnectType connection = EnumConnectType.NONE;
-		if (tile instanceof IFluidPipe) {
+		if (otherTile instanceof IFluidPipe) {
 			connection = EnumConnectType.WIRE;
-		} else if (FluidUtilities.isFluidReceiver(tile, dir.getOpposite())) {
+		} else if (FluidUtilities.isFluidReceiver(otherTile, dir.getOpposite())) {
 			connection = EnumConnectType.INVENTORY;
 		}
-		connect.writeConnection(dir, connection);
+		thisConnect.writeConnection(dir, connection);
 		return state;
 	}
 

--- a/src/main/java/electrodynamics/common/block/connect/BlockGasPipe.java
+++ b/src/main/java/electrodynamics/common/block/connect/BlockGasPipe.java
@@ -93,15 +93,18 @@ public class BlockGasPipe extends AbstractRefreshingConnectBlock {
 	}
 
 	@Override
-	public BlockState refreshConnections(BlockState otherState, BlockEntity tile, BlockState state, Direction dir) {
-		GenericConnectTile connect = (GenericConnectTile) tile;
+	public BlockState refreshConnections(BlockState otherState, BlockEntity otherTile, BlockState state, BlockEntity thisTile, Direction dir) {
+		if(!(thisTile instanceof GenericConnectTile)) {
+			return state;
+		}
+		GenericConnectTile thisConnect = (GenericConnectTile) thisTile;
 		EnumConnectType connection = EnumConnectType.NONE;
-		if (tile instanceof IGasPipe) {
+		if (otherTile instanceof IGasPipe) {
 			connection = EnumConnectType.WIRE;
-		} else if (GasUtilities.isGasReciever(tile, dir.getOpposite())) {
+		} else if (GasUtilities.isGasReciever(otherTile, dir.getOpposite())) {
 			connection = EnumConnectType.INVENTORY;
 		}
-		connect.writeConnection(dir, connection);
+		thisConnect.writeConnection(dir, connection);
 		return state;
 	}
 

--- a/src/main/java/electrodynamics/common/block/connect/BlockWire.java
+++ b/src/main/java/electrodynamics/common/block/connect/BlockWire.java
@@ -358,15 +358,22 @@ public class BlockWire extends AbstractRefreshingConnectBlock {
 	}
 
 	@Override
-	public BlockState refreshConnections(BlockState otherState, BlockEntity tile, BlockState state, Direction dir) {
-		GenericConnectTile connect = (GenericConnectTile) tile;
+	public BlockState refreshConnections(BlockState otherState, BlockEntity otherTile, BlockState state, BlockEntity thisTile, Direction dir) {
+		if(!(thisTile instanceof GenericConnectTile)) {
+			return state;
+		}
+		GenericConnectTile thisConnect = (GenericConnectTile) thisTile;
 		EnumConnectType connection = EnumConnectType.NONE;
-		if (tile instanceof IConductor conductor && (conductor.getWireType().isDefaultColor() || wire.isDefaultColor() || conductor.getWireColor() == wire.color)) {
-			connection = EnumConnectType.WIRE;
-		} else if (ElectricityUtils.isElectricReceiver(tile, dir.getOpposite()) || checkRedstone(otherState)) {
+		if (otherTile instanceof IConductor conductor) {
+			if(conductor.getWireType().isDefaultColor() || wire.isDefaultColor() || conductor.getWireColor() == wire.color) {
+				connection = EnumConnectType.WIRE;
+			} else {
+				connection = EnumConnectType.NONE;
+			}
+		} else if (ElectricityUtils.isElectricReceiver(otherTile, dir.getOpposite()) || checkRedstone(otherState)) {
 			connection = EnumConnectType.INVENTORY;
 		}
-		connect.writeConnection(dir, connection);
+		thisConnect.writeConnection(dir, connection);
 		return state;
 	}
 

--- a/src/main/java/electrodynamics/common/block/connect/util/AbstractConnectBlock.java
+++ b/src/main/java/electrodynamics/common/block/connect/util/AbstractConnectBlock.java
@@ -36,7 +36,7 @@ public abstract class AbstractConnectBlock extends GenericEntityBlockWaterloggab
 	protected final VoxelShape[] boundingBoxes = new VoxelShape[7];
 
 	protected HashMap<EnumConnectType[], VoxelShape> shapestates = new HashMap<>();
-	protected boolean locked = false;
+	//protected boolean locked = false;
 
 	public AbstractConnectBlock(Properties properties, double radius) {
 		super(properties);
@@ -98,12 +98,9 @@ public abstract class AbstractConnectBlock extends GenericEntityBlockWaterloggab
 			}
 
 		}
-		locked = true;
 		if (shapestates.containsKey(checked)) {
-			locked = false;
 			return Shapes.join(shapestates.get(checked), camoShape, BooleanOp.OR);
 		}
-		locked = false;
 		for (int i = 0; i < 6; i++) {
 			
 			EnumConnectType connection = checked[i];
@@ -113,9 +110,6 @@ public abstract class AbstractConnectBlock extends GenericEntityBlockWaterloggab
 			}
 			
 			shape = Shapes.join(shape, boundingBoxes[i], BooleanOp.OR);
-		}
-		while (locked) {
-			System.out.println("Bounding box collided with another block's bounding box!");
 		}
 		shapestates.put(checked, shape);
 		if (shape == null) {

--- a/src/main/java/electrodynamics/common/block/connect/util/AbstractRefreshingConnectBlock.java
+++ b/src/main/java/electrodynamics/common/block/connect/util/AbstractRefreshingConnectBlock.java
@@ -13,8 +13,6 @@ import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraft.world.level.material.Fluids;
 
 public abstract class AbstractRefreshingConnectBlock extends AbstractConnectBlock {
 
@@ -28,18 +26,14 @@ public abstract class AbstractRefreshingConnectBlock extends AbstractConnectBloc
 		BlockPos relPos;
 		for (Direction dir : Direction.values()) {
 			relPos = pos.relative(dir);
-			stateIn = refreshConnections(worldIn.getBlockState(relPos), worldIn.getBlockEntity(relPos), stateIn, dir);
+			stateIn = refreshConnections(worldIn.getBlockState(relPos), worldIn.getBlockEntity(relPos), stateIn, worldIn.getBlockEntity(pos), dir);
 		}
 		worldIn.setBlockAndUpdate(pos, stateIn);
 	}
 
 	@Override
 	public BlockState updateShape(BlockState stateIn, Direction facing, BlockState facingState, LevelAccessor world, BlockPos currentPos, BlockPos facingPos) {
-		stateIn = super.updateShape(stateIn, facing, facingState, world, currentPos, facingPos);
-		if (stateIn.getValue(BlockStateProperties.WATERLOGGED)) {
-			world.scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickDelay(world));
-		}
-		return refreshConnections(facingState, world.getBlockEntity(facingPos), stateIn, facing);
+		return refreshConnections(facingState, world.getBlockEntity(facingPos), super.updateShape(stateIn, facing, facingState, world, currentPos, facingPos), world.getBlockEntity(currentPos), facing);
 	}
 
 	@Override
@@ -57,7 +51,7 @@ public abstract class AbstractRefreshingConnectBlock extends AbstractConnectBloc
 		BlockPos relPos;
 		for (Direction dir : Direction.values()) {
 			relPos = pos.relative(dir);
-			state = refreshConnections(worldIn.getBlockState(relPos), worldIn.getBlockEntity(relPos), state, dir);
+			state = refreshConnections(worldIn.getBlockState(relPos), worldIn.getBlockEntity(relPos), state, worldIn.getBlockEntity(pos), dir);
 		}
 		state = state.setValue(ElectrodynamicsBlockStates.HAS_SCAFFOLDING, state.getValue(ElectrodynamicsBlockStates.HAS_SCAFFOLDING));
 		worldIn.setBlockAndUpdate(pos, state);
@@ -77,7 +71,7 @@ public abstract class AbstractRefreshingConnectBlock extends AbstractConnectBloc
 		conductor.refreshNetworkIfChange();
 	}
 
-	public abstract BlockState refreshConnections(BlockState otherState, BlockEntity tile, BlockState thisState, Direction dir);
+	public abstract BlockState refreshConnections(BlockState otherState, BlockEntity otherTile, BlockState thisState, BlockEntity thisTile, Direction dir);
 
 	@Nullable
 	public abstract IRefreshableCable getCableIfValid(BlockEntity tile);

--- a/src/main/java/electrodynamics/common/tile/pipelines/fluids/GenericTileFluidPipe.java
+++ b/src/main/java/electrodynamics/common/tile/pipelines/fluids/GenericTileFluidPipe.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
 import com.google.common.collect.Sets;
 
 import electrodynamics.api.network.cable.type.IFluidPipe;
+import electrodynamics.common.block.connect.util.EnumConnectType;
 import electrodynamics.common.network.type.FluidNetwork;
 import electrodynamics.common.network.utils.FluidUtilities;
 import electrodynamics.prefab.network.AbstractNetwork;
@@ -229,6 +230,20 @@ public abstract class GenericTileFluidPipe extends GenericConnectTile implements
 	@Override
 	public void onLoad() {
 		super.onLoad();
+		// TODO remove in next version release; this is a temp hack for now
+		if (super.connections.get() == 0) {
+			for (Direction dir : Direction.values()) {
+				EnumConnectType connection = EnumConnectType.NONE;
+				BlockEntity otherTile = level.getBlockEntity(getBlockPos().relative(dir));
+				if (otherTile instanceof IFluidPipe) {
+					connection = EnumConnectType.WIRE;
+				} else if (FluidUtilities.isFluidReceiver(otherTile, dir.getOpposite())) {
+					connection = EnumConnectType.INVENTORY;
+				}
+				writeConnection(dir, connection);
+			}
+		}
+		// end temp hack
 		Scheduler.schedule(1, this::refreshNetwork);
 	}
 }

--- a/src/main/java/electrodynamics/common/tile/pipelines/gas/GenericTileGasPipe.java
+++ b/src/main/java/electrodynamics/common/tile/pipelines/gas/GenericTileGasPipe.java
@@ -12,8 +12,8 @@ import electrodynamics.api.capability.ElectrodynamicsCapabilities;
 import electrodynamics.api.capability.types.gas.IGasHandler;
 import electrodynamics.api.gas.GasAction;
 import electrodynamics.api.gas.GasStack;
-import electrodynamics.api.network.cable.type.IFluidPipe;
 import electrodynamics.api.network.cable.type.IGasPipe;
+import electrodynamics.common.block.connect.util.EnumConnectType;
 import electrodynamics.common.network.type.GasNetwork;
 import electrodynamics.common.network.utils.GasUtilities;
 import electrodynamics.prefab.network.AbstractNetwork;
@@ -159,7 +159,7 @@ public abstract class GenericTileGasPipe extends GenericConnectTile implements I
 		ArrayList<GasNetwork> foundNetworks = new ArrayList<>();
 		for (Direction dir : Direction.values()) {
 			BlockEntity facing = level.getBlockEntity(new BlockPos(worldPosition).relative(dir));
-			if (facing instanceof IFluidPipe p && p.getNetwork() instanceof GasNetwork n) {
+			if (facing instanceof IGasPipe p && p.getNetwork() instanceof GasNetwork n) {
 				foundNetworks.add(n);
 			}
 		}
@@ -243,6 +243,20 @@ public abstract class GenericTileGasPipe extends GenericConnectTile implements I
 	@Override
 	public void onLoad() {
 		super.onLoad();
+		// TODO remove in next version release; this is a temp hack for now
+		if (super.connections.get() == 0) {
+			for (Direction dir : Direction.values()) {
+				EnumConnectType connection = EnumConnectType.NONE;
+				BlockEntity otherTile = level.getBlockEntity(getBlockPos().relative(dir));
+				if (otherTile instanceof IGasPipe) {
+					connection = EnumConnectType.WIRE;
+				} else if (GasUtilities.isGasReciever(otherTile, dir.getOpposite())) {
+					connection = EnumConnectType.INVENTORY;
+				}
+				writeConnection(dir, connection);
+			}
+		}
+		// end temp hack
 		Scheduler.schedule(1, this::refreshNetwork);
 	}
 

--- a/src/main/java/electrodynamics/datagen/client/ElectrodynamicsBlockStateProvider.java
+++ b/src/main/java/electrodynamics/datagen/client/ElectrodynamicsBlockStateProvider.java
@@ -183,12 +183,12 @@ public class ElectrodynamicsBlockStateProvider extends BlockStateProvider {
 
 		// bare
 		for (SubtypeWire wire : SubtypeWire.getWires(Conductor.values(), InsulationMaterial.BARE, WireClass.BARE, WireColor.NONE)) {
-			wire(ElectrodynamicsBlocks.getBlock(wire), models().withExistingParent(name + wire.tag() + "_none", modLoc(parent + "wire_none")).texture("conductor", blockLoc(texture + wire.conductor.toString())).texture("particle", "#conductor"), models().withExistingParent(name + wire.tag() + "_side", modLoc(parent + "wire_side")).texture("conductor", blockLoc(texture + wire.conductor.toString())).texture("particle", "#conductor"), false);
+			wire(ElectrodynamicsBlocks.getBlock(wire), models().withExistingParent(name + wire.tag() + "_none", modLoc(parent + "wire_none")).texture("conductor", blockLoc(texture + wire.conductor.toString())).texture("particle", "#conductor").renderType("cutout"), models().withExistingParent(name + wire.tag() + "_side", modLoc(parent + "wire_side")).texture("conductor", blockLoc(texture + wire.conductor.toString())).texture("particle", "#conductor").renderType("cutout"), false);
 		}
 
 		// insulated
 		for (SubtypeWire wire : SubtypeWire.getWires(Conductor.values(), InsulationMaterial.WOOL, WireClass.INSULATED, WireColor.values())) {
-			wire(ElectrodynamicsBlocks.getBlock(wire), models().withExistingParent(name + wire.tag() + "_none", modLoc(parent + "insulatedwire_none")).texture("conductor", blockLoc(texture + wire.conductor.toString() + "_center")).texture("insulation", blockLoc(texture + "insulationwool_center")).texture("particle", "#insulation").renderType("cutout"), models().withExistingParent(name + wire.tag() + "_side", modLoc(parent + "insulatedwire_side")).texture("insulation", blockLoc(texture + "insulationwool")).texture("particle", "#insulation"), false);
+			wire(ElectrodynamicsBlocks.getBlock(wire), models().withExistingParent(name + wire.tag() + "_none", modLoc(parent + "insulatedwire_none")).texture("conductor", blockLoc(texture + wire.conductor.toString() + "_center")).texture("insulation", blockLoc(texture + "insulationwool_center")).texture("particle", "#insulation").renderType("cutout"), models().withExistingParent(name + wire.tag() + "_side", modLoc(parent + "insulatedwire_side")).texture("insulation", blockLoc(texture + "insulationwool")).texture("particle", "#insulation").renderType("cutout"), false);
 		}
 
 		// logistical
@@ -198,12 +198,12 @@ public class ElectrodynamicsBlockStateProvider extends BlockStateProvider {
 
 		// ceramic
 		for (SubtypeWire wire : SubtypeWire.getWires(Conductor.values(), InsulationMaterial.CERAMIC, WireClass.CERAMIC, WireColor.values())) {
-			wire(ElectrodynamicsBlocks.getBlock(wire), models().withExistingParent(name + wire.tag() + "_none", modLoc(parent + "ceramicinsulatedwire_none")).texture("conductor", blockLoc(texture + wire.conductor.toString() + "_center")).texture("insulation", blockLoc(texture + "insulationceramic_center_base")).texture("particle", "#insulation").renderType("cutout"), models().withExistingParent(name + wire.tag() + "_side", modLoc(parent + "ceramicinsulatedwire_side")).texture("insulationbase", blockLoc(texture + "insulationceramic_base")).texture("insulationcolor", blockLoc(texture + "insulationceramic")).texture("particle", "#insulationcolor"), false);
+			wire(ElectrodynamicsBlocks.getBlock(wire), models().withExistingParent(name + wire.tag() + "_none", modLoc(parent + "ceramicinsulatedwire_none")).texture("conductor", blockLoc(texture + wire.conductor.toString() + "_center")).texture("insulation", blockLoc(texture + "insulationceramic_center_base")).texture("particle", "#insulation").renderType("cutout"), models().withExistingParent(name + wire.tag() + "_side", modLoc(parent + "ceramicinsulatedwire_side")).texture("insulationbase", blockLoc(texture + "insulationceramic_base")).texture("insulationcolor", blockLoc(texture + "insulationceramic")).texture("particle", "#insulationcolor").renderType("cutout"), false);
 		}
 
 		// highly insulated
 		for (SubtypeWire wire : SubtypeWire.getWires(Conductor.values(), InsulationMaterial.THICK_WOOL, WireClass.THICK, WireColor.values())) {
-			wire(ElectrodynamicsBlocks.getBlock(wire), models().withExistingParent(name + wire.tag() + "_none", modLoc(parent + "highlyinsulatedwire_none")).texture("conductor", blockLoc(texture + wire.conductor.toString() + "_center")).texture("insulation", blockLoc(texture + "insulationwool_center")).texture("particle", "#insulation").renderType("cutout"), models().withExistingParent(name + wire.tag() + "_side", modLoc(parent + "highlyinsulatedwire_side")).texture("insulation", blockLoc(texture + "insulationwool")).texture("particle", "#insulation"), false);
+			wire(ElectrodynamicsBlocks.getBlock(wire), models().withExistingParent(name + wire.tag() + "_none", modLoc(parent + "highlyinsulatedwire_none")).texture("conductor", blockLoc(texture + wire.conductor.toString() + "_center")).texture("insulation", blockLoc(texture + "insulationwool_center")).texture("particle", "#insulation").renderType("cutout"), models().withExistingParent(name + wire.tag() + "_side", modLoc(parent + "highlyinsulatedwire_side")).texture("insulation", blockLoc(texture + "insulationwool")).texture("particle", "#insulation").renderType("cutout"), false);
 		}
 
 	}

--- a/src/main/java/electrodynamics/datagen/client/ElectrodynamicsBlockStateProvider.java
+++ b/src/main/java/electrodynamics/datagen/client/ElectrodynamicsBlockStateProvider.java
@@ -20,7 +20,8 @@ import electrodynamics.common.block.subtype.SubtypeWire.Conductor;
 import electrodynamics.common.block.subtype.SubtypeWire.InsulationMaterial;
 import electrodynamics.common.block.subtype.SubtypeWire.WireClass;
 import electrodynamics.common.block.subtype.SubtypeWire.WireColor;
-import electrodynamics.datagen.utils.GeneratedBlockStateCableModel;
+import electrodynamics.datagen.utils.model.GeneratedBlockStateCableModel;
+import electrodynamics.datagen.utils.model.WireModelBuilder;
 import electrodynamics.prefab.block.GenericEntityBlock;
 import electrodynamics.registers.ElectrodynamicsBlocks;
 import net.minecraft.core.Direction;
@@ -434,7 +435,9 @@ public class ElectrodynamicsBlockStateProvider extends BlockStateProvider {
 	 * 
 	 */
 	public void wire(Block block, ModelFile none, ModelFile side, boolean registerItem) {
-		registeredBlocks.put(block, new GeneratedBlockStateCableModel(none, side, side));
+		ModelFile model = models().withExistingParent(name(block), new ResourceLocation("cube")).customLoader(WireModelBuilder::begin).models(none, side, side).end().renderType(new ResourceLocation("cutout"));
+		
+		getVariantBuilder(block).partialState().addModels(new ConfiguredModel(model));
 		/*
 		getMultipartBuilder(block).part()
 			.modelFile(none).addModel().useOr()

--- a/src/main/java/electrodynamics/datagen/client/ElectrodynamicsBlockStateProvider.java
+++ b/src/main/java/electrodynamics/datagen/client/ElectrodynamicsBlockStateProvider.java
@@ -3,7 +3,6 @@ package electrodynamics.datagen.client;
 import javax.annotation.Nullable;
 
 import electrodynamics.api.References;
-import electrodynamics.common.block.connect.util.EnumConnectType;
 import electrodynamics.common.block.states.ElectrodynamicsBlockStates;
 import electrodynamics.common.block.states.ElectrodynamicsBlockStates.AddonTankNeighborType;
 import electrodynamics.common.block.states.ElectrodynamicsBlockStates.ManipulatorHeatingStatus;
@@ -20,7 +19,6 @@ import electrodynamics.common.block.subtype.SubtypeWire.Conductor;
 import electrodynamics.common.block.subtype.SubtypeWire.InsulationMaterial;
 import electrodynamics.common.block.subtype.SubtypeWire.WireClass;
 import electrodynamics.common.block.subtype.SubtypeWire.WireColor;
-import electrodynamics.datagen.utils.model.GeneratedBlockStateCableModel;
 import electrodynamics.datagen.utils.model.WireModelBuilder;
 import electrodynamics.prefab.block.GenericEntityBlock;
 import electrodynamics.registers.ElectrodynamicsBlocks;

--- a/src/main/java/electrodynamics/datagen/utils/model/GeneratedBlockStateCableModel.java
+++ b/src/main/java/electrodynamics/datagen/utils/model/GeneratedBlockStateCableModel.java
@@ -1,4 +1,4 @@
-package electrodynamics.datagen.utils;
+package electrodynamics.datagen.utils.model;
 
 import com.google.gson.JsonObject;
 
@@ -29,15 +29,18 @@ public class GeneratedBlockStateCableModel implements IGeneratedBlockState {
 		json.addProperty("loader", References.ID + ":" + CableModelLoader.ID);
 
 		JsonObject noneElement = new JsonObject();
-		noneElement.addProperty("model", none.getLocation().toString());
+		noneElement.addProperty("parent", none.getLocation().toString());
+		
+		
+		
 		json.add(EnumConnectType.NONE.toString(), noneElement);
 
 		JsonObject wireElement = new JsonObject();
-		wireElement.addProperty("model", wire.getLocation().toString());
+		wireElement.addProperty("parent", wire.getLocation().toString());
 		json.add(EnumConnectType.WIRE.toString(), wireElement);
 
 		JsonObject inventoryElement = new JsonObject();
-		inventoryElement.addProperty("model", inventory.getLocation().toString());
+		inventoryElement.addProperty("parent", inventory.getLocation().toString());
 		json.add(EnumConnectType.INVENTORY.toString(), inventoryElement);
 
 		return json;

--- a/src/main/java/electrodynamics/datagen/utils/model/WireModelBuilder.java
+++ b/src/main/java/electrodynamics/datagen/utils/model/WireModelBuilder.java
@@ -1,0 +1,56 @@
+package electrodynamics.datagen.utils.model;
+
+import com.google.gson.JsonObject;
+
+import electrodynamics.api.References;
+import electrodynamics.client.modelbakers.bakerypes.CableModelLoader;
+import electrodynamics.common.block.connect.util.EnumConnectType;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.client.model.generators.CustomLoaderBuilder;
+import net.minecraftforge.client.model.generators.ModelBuilder;
+import net.minecraftforge.client.model.generators.ModelFile;
+import net.minecraftforge.common.data.ExistingFileHelper;
+
+public class WireModelBuilder<T extends ModelBuilder<T>> extends CustomLoaderBuilder<T> {
+
+	public static <T extends ModelBuilder<T>> WireModelBuilder<T> begin(T parent, ExistingFileHelper existingFileHelper) {
+		return new WireModelBuilder<>(parent, existingFileHelper);
+	}
+
+	private ModelFile none;
+	private ModelFile wire;
+	private ModelFile inventory;
+
+	protected WireModelBuilder(T parent, ExistingFileHelper existingFileHelper) {
+		super(new ResourceLocation(References.ID, CableModelLoader.ID), parent, existingFileHelper);
+
+	}
+
+	public WireModelBuilder<T> models(ModelFile none, ModelFile wire, ModelFile inventory) {
+		this.none = none;
+		this.wire = wire;
+		this.inventory = inventory;
+
+		return this;
+	}
+
+	@Override
+	public JsonObject toJson(JsonObject json) {
+		json = super.toJson(json);
+
+		JsonObject noneElement = new JsonObject();
+		noneElement.addProperty("parent", none.getLocation().toString());
+		json.add(EnumConnectType.NONE.toString(), noneElement);
+
+		JsonObject wireElement = new JsonObject();
+		wireElement.addProperty("parent", wire.getLocation().toString());
+		json.add(EnumConnectType.WIRE.toString(), wireElement);
+
+		JsonObject inventoryElement = new JsonObject();
+		inventoryElement.addProperty("parent", inventory.getLocation().toString());
+		json.add(EnumConnectType.INVENTORY.toString(), inventoryElement);
+
+		return json;
+	}
+
+}

--- a/src/main/java/electrodynamics/prefab/tile/types/GenericConnectTile.java
+++ b/src/main/java/electrodynamics/prefab/tile/types/GenericConnectTile.java
@@ -16,7 +16,7 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.client.model.data.ModelData;
 
-public abstract class GenericConnectTile extends GenericTile {
+public abstract class GenericConnectTile extends GenericTile implements IConnectTile {
 
 	// DUNSWE
 

--- a/src/main/java/electrodynamics/prefab/tile/types/GenericConnectTile.java
+++ b/src/main/java/electrodynamics/prefab/tile/types/GenericConnectTile.java
@@ -20,18 +20,19 @@ public abstract class GenericConnectTile extends GenericTile {
 
 	// DUNSWE
 
-	public static final int DOWN_MASK = 0b11110000000000000000000000000000;
-	public static final int UP_MASK = 0b00001111000000000000000000000000;
-	public static final int NORTH_MASK = 0b00000000111100000000000000000000;
-	public static final int SOUTH_MASK = 0b00000000000011110000000000000000;
-	public static final int WEST_MASK = 0b00000000000000001111000000000000;
-	public static final int EAST_MASK = 0b00000000000000000000111100000000;
+	public static final int DOWN_MASK = 0b00000000000000000000000000001111;
+	public static final int UP_MASK = 0b00000000000000000000000011110000;
+	public static final int NORTH_MASK = 0b00000000000000000000111100000000;
+	public static final int SOUTH_MASK = 0b00000000000000001111000000000000;
+	public static final int WEST_MASK = 0b00000000000011110000000000000000;
+	public static final int EAST_MASK = 0b00000000111100000000000000000000;
 
-	public final Property<Integer> connections = property(new Property<>(PropertyType.Integer, "connections", 0).onChange((property, block) -> {
+	public final Property<Integer> connections = property(new Property<>(PropertyType.Integer, "connections", 0).onChange((property, old) -> {
 		if(!level.isClientSide) {
 			return;
 		}
 		requestModelDataUpdate();
+		
 	}));
 
 	public final Property<BlockState> camoflaugedBlock = property(new Property<>(PropertyType.Blockstate, "camoflaugedblock", Blocks.AIR.defaultBlockState())).onChange((property, block) -> {
@@ -78,12 +79,17 @@ public abstract class GenericConnectTile extends GenericTile {
 		super.onPlace(oldState, isMoving);
 		if (!level.isClientSide) {
 			this.<ComponentPacketHandler>getComponent(IComponentType.PacketHandler).sendProperties();
-		}
+		} 
 	}
 
 	public EnumConnectType readConnection(Direction dir) {
 
 		int connectionData = connections.get();
+		
+		if(connectionData == 0) {
+			return EnumConnectType.NONE;
+		}
+		
 		int extracted = 0;
 		switch (dir) {
 		case DOWN:
@@ -108,39 +114,42 @@ public abstract class GenericConnectTile extends GenericTile {
 			break;
 		}
 		
-		return EnumConnectType.values()[(extracted << dir.ordinal() * 4)];
+		//return EnumConnectType.NONE;
+		
+		return EnumConnectType.values()[(extracted >> (dir.ordinal() * 4))];
 
 	}
 	
 	public void writeConnection(Direction dir, EnumConnectType connection) {
 		
-		int connectionData = connections.get();
+		int connectionData = this.connections.get();
+		int masked;
 
 		switch (dir) {
 		case DOWN:
-			connectionData = connectionData & ~DOWN_MASK;
+			masked = connectionData & ~DOWN_MASK;
 			break;
 		case UP:
-			connectionData = connectionData & ~UP_MASK;
+			masked = connectionData & ~UP_MASK;
 			break;
 		case NORTH:
-			connectionData = connectionData & ~NORTH_MASK;
+			masked = connectionData & ~NORTH_MASK;
 			break;
 		case SOUTH:
-			connectionData = connectionData & ~SOUTH_MASK;
+			masked = connectionData & ~SOUTH_MASK;
 			break;
 		case WEST:
-			connectionData = connectionData & ~WEST_MASK;
+			masked = connectionData & ~WEST_MASK;
 			break;
 		case EAST:
-			connectionData = connectionData & ~EAST_MASK;
+			masked = connectionData & ~EAST_MASK;
 			break;
 		default:
+			masked = 0;
 			break;
 		}
-		connectionData = connectionData | (connection.ordinal() >> dir.ordinal() * 4);
 		
-		connections.set(connectionData);
+		connections.set(masked | (connection.ordinal() << (dir.ordinal() * 4)));
 	}
 	
 	public EnumConnectType[] readConnections() {
@@ -155,5 +164,7 @@ public abstract class GenericConnectTile extends GenericTile {
 	public @NotNull ModelData getModelData() {
 		return ModelData.builder().with(ModelPropertyConnections.INSTANCE, readConnections()).build();
 	}
+	
+	
 
 }

--- a/src/main/java/electrodynamics/prefab/tile/types/IConnectTile.java
+++ b/src/main/java/electrodynamics/prefab/tile/types/IConnectTile.java
@@ -1,0 +1,9 @@
+package electrodynamics.prefab.tile.types;
+
+import electrodynamics.common.block.connect.util.EnumConnectType;
+
+public interface IConnectTile {
+	
+	public EnumConnectType[] readConnections();
+
+}

--- a/src/main/java/electrodynamics/prefab/utilities/ItemUtils.java
+++ b/src/main/java/electrodynamics/prefab/utilities/ItemUtils.java
@@ -1,12 +1,19 @@
 package electrodynamics.prefab.utilities;
 
+import java.util.Iterator;
+
 import javax.annotation.Nullable;
 
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.block.Block;
 
 public class ItemUtils {
@@ -51,6 +58,18 @@ public class ItemUtils {
 			}
 		}
 		return false;
+	}
+	
+	public static void removeEnchantment(ItemStack item, Enchantment enchantment) {
+		ListTag listtag = item.getOrCreateTag().getList("Enchantments", 10);
+		Iterator<Tag> iterator = listtag.iterator();
+		CompoundTag itTag;
+		while(iterator.hasNext()) {
+			itTag = (CompoundTag) iterator.next();
+			if(itTag.contains("id") && new ResourceLocation(itTag.getString("id")).equals(EnchantmentHelper.getEnchantmentId(enchantment))) {
+				iterator.remove();
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
>Rework cable rendering to reduce blockstates; this may cause some visual bugs on existing wires in existing worlds, however the wires will still work perfectly. Newly placed wires will have no issues.
>Fix enchantment issues on drill.