### PR TITLE
Electric item changes: swap battery correctly and remove all but one use of `ElectricItemProperties#capacity`

### DIFF
--- a/src/main/java/electrodynamics/client/screen/tile/ScreenChargerGeneric.java
+++ b/src/main/java/electrodynamics/client/screen/tile/ScreenChargerGeneric.java
@@ -30,7 +30,7 @@ public class ScreenChargerGeneric extends GenericScreen<ContainerChargerGeneric>
 			if (charger != null) {
 				ItemStack chargingItem = menu.getSlot(0).getItem();
 				if (!chargingItem.isEmpty() && chargingItem.getItem() instanceof IItemElectric electricItem) {
-					return electricItem.getJoulesStored(chargingItem) / electricItem.getElectricProperties().capacity;
+					return electricItem.getJoulesStored(chargingItem) / electricItem.getMaximumCapacity(chargingItem);
 				}
 			}
 			return 0;
@@ -54,7 +54,7 @@ public class ScreenChargerGeneric extends GenericScreen<ContainerChargerGeneric>
 
 				ComponentElectrodynamic electro = charger.getComponent(IComponentType.Electrodynamic);
 
-				chargingPercentage = electricItem.getJoulesStored(chargingItem) / electricItem.getElectricProperties().capacity * 100;
+				chargingPercentage = electricItem.getJoulesStored(chargingItem) / electricItem.getMaximumCapacity(chargingItem) * 100;
 				chargeCapable = electro.getVoltage() / electricItem.getElectricProperties().receive.getVoltage() * 100;
 			}
 

--- a/src/main/java/electrodynamics/common/item/gear/armor/types/ItemCombatArmor.java
+++ b/src/main/java/electrodynamics/common/item/gear/armor/types/ItemCombatArmor.java
@@ -147,7 +147,7 @@ public class ItemCombatArmor extends ItemElectrodynamicsArmor implements IItemEl
         items.add(empty);
 
         ItemStack charged = new ItemStack(this);
-        IItemElectric.setEnergyStored(charged, properties.capacity);
+        IItemElectric.setEnergyStored(charged, getMaximumCapacity(charged));
         items.add(charged);
         break;
       case CHEST:
@@ -268,7 +268,7 @@ public class ItemCombatArmor extends ItemElectrodynamicsArmor implements IItemEl
     ItemCombatArmor combat = (ItemCombatArmor) stack.getItem();
     switch (combat.getEquipmentSlot()) {
       case HEAD, LEGS:
-        return getJoulesStored(stack) < properties.capacity;
+        return getJoulesStored(stack) < getMaximumCapacity(stack);
       case CHEST:
         return ItemJetpack.staticIsBarVisible(stack);
       case FEET:
@@ -283,7 +283,7 @@ public class ItemCombatArmor extends ItemElectrodynamicsArmor implements IItemEl
     ItemCombatArmor combat = (ItemCombatArmor) stack.getItem();
     switch (combat.getEquipmentSlot()) {
       case HEAD, LEGS:
-        return (int) Math.round(13.0f * getJoulesStored(stack) / properties.capacity);
+        return (int) Math.round(13.0f * getJoulesStored(stack) / getMaximumCapacity(stack));
       case CHEST:
         return ItemJetpack.staticGetBarWidth(stack);
       case FEET:

--- a/src/main/java/electrodynamics/common/item/gear/armor/types/ItemNightVisionGoggles.java
+++ b/src/main/java/electrodynamics/common/item/gear/armor/types/ItemNightVisionGoggles.java
@@ -111,12 +111,12 @@ public class ItemNightVisionGoggles extends ItemElectrodynamicsArmor implements 
 
 	@Override
 	public int getBarWidth(ItemStack stack) {
-		return (int) Math.round(13.0f * getJoulesStored(stack) / properties.capacity);
+		return (int) Math.round(13.0f * getJoulesStored(stack) / getMaximumCapacity(stack));
 	}
 
 	@Override
 	public boolean isBarVisible(ItemStack stack) {
-		return getJoulesStored(stack) < properties.capacity;
+		return getJoulesStored(stack) < getMaximumCapacity(stack);
 	}
 
 	@Override
@@ -140,7 +140,7 @@ public class ItemNightVisionGoggles extends ItemElectrodynamicsArmor implements 
 		items.add(empty);
 
 		ItemStack charged = new ItemStack(this);
-		IItemElectric.setEnergyStored(charged, properties.capacity);
+		IItemElectric.setEnergyStored(charged, getMaximumCapacity(charged));
 		items.add(charged);
 
 	}

--- a/src/main/java/electrodynamics/common/item/gear/armor/types/ItemServoLeggings.java
+++ b/src/main/java/electrodynamics/common/item/gear/armor/types/ItemServoLeggings.java
@@ -93,12 +93,12 @@ public class ItemServoLeggings extends ItemElectrodynamicsArmor implements IItem
 
 	@Override
 	public int getBarWidth(ItemStack stack) {
-		return (int) Math.round(13.0f * getJoulesStored(stack) / properties.capacity);
+		return (int) Math.round(13.0f * getJoulesStored(stack) / getMaximumCapacity(stack));
 	}
 
 	@Override
 	public boolean isBarVisible(ItemStack stack) {
-		return getJoulesStored(stack) < properties.capacity;
+		return getJoulesStored(stack) < getMaximumCapacity(stack);
 	}
 
 	@Override
@@ -144,7 +144,7 @@ public class ItemServoLeggings extends ItemElectrodynamicsArmor implements IItem
 		items.add(empty);
 
 		ItemStack charged = new ItemStack(this);
-		IItemElectric.setEnergyStored(charged, properties.capacity);
+		IItemElectric.setEnergyStored(charged, getMaximumCapacity(charged));
 		items.add(charged);
 
 	}

--- a/src/main/java/electrodynamics/common/item/gear/tools/electric/ItemElectricBaton.java
+++ b/src/main/java/electrodynamics/common/item/gear/tools/electric/ItemElectricBaton.java
@@ -61,7 +61,7 @@ public class ItemElectricBaton extends SwordItem implements IItemElectric, Creat
 		items.add(empty);
 
 		ItemStack charged = new ItemStack(this);
-		IItemElectric.setEnergyStored(charged, properties.capacity);
+		IItemElectric.setEnergyStored(charged, getMaximumCapacity(charged));
 		items.add(charged);
 
 	}
@@ -79,12 +79,12 @@ public class ItemElectricBaton extends SwordItem implements IItemElectric, Creat
 
 	@Override
 	public int getBarWidth(ItemStack stack) {
-		return (int) Math.round(13.0f * getJoulesStored(stack) / properties.capacity);
+		return (int) Math.round(13.0f * getJoulesStored(stack) / getMaximumCapacity(stack));
 	}
 
 	@Override
 	public boolean isBarVisible(ItemStack stack) {
-		return getJoulesStored(stack) < properties.capacity;
+		return getJoulesStored(stack) < getMaximumCapacity(stack);
 	}
 
 	@Override

--- a/src/main/java/electrodynamics/common/item/gear/tools/electric/ItemElectricChainsaw.java
+++ b/src/main/java/electrodynamics/common/item/gear/tools/electric/ItemElectricChainsaw.java
@@ -54,7 +54,7 @@ public class ItemElectricChainsaw extends DiggerItem implements IItemElectric, C
 		items.add(empty);
 
 		ItemStack charged = new ItemStack(this);
-		IItemElectric.setEnergyStored(charged, properties.capacity);
+		IItemElectric.setEnergyStored(charged, getMaximumCapacity(charged));
 		items.add(charged);
 
 	}
@@ -77,12 +77,12 @@ public class ItemElectricChainsaw extends DiggerItem implements IItemElectric, C
 
 	@Override
 	public int getBarWidth(ItemStack stack) {
-		return (int) Math.round(13.0f * getJoulesStored(stack) / properties.capacity);
+		return (int) Math.round(13.0f * getJoulesStored(stack) / getMaximumCapacity(stack));
 	}
 
 	@Override
 	public boolean isBarVisible(ItemStack stack) {
-		return getJoulesStored(stack) < properties.capacity;
+		return getJoulesStored(stack) < getMaximumCapacity(stack);
 	}
 
 	@Override

--- a/src/main/java/electrodynamics/common/item/gear/tools/electric/ItemElectricDrill.java
+++ b/src/main/java/electrodynamics/common/item/gear/tools/electric/ItemElectricDrill.java
@@ -150,7 +150,7 @@ public class ItemElectricDrill extends ItemMultiDigger implements IItemElectric,
 		items.add(empty);
 
 		ItemStack charged = new ItemStack(this);
-		IItemElectric.setEnergyStored(charged, properties.capacity);
+		IItemElectric.setEnergyStored(charged, getMaximumCapacity(charged));
 		items.add(charged);
 
 	}
@@ -199,12 +199,12 @@ public class ItemElectricDrill extends ItemMultiDigger implements IItemElectric,
 
 	@Override
 	public int getBarWidth(ItemStack stack) {
-		return (int) Math.round(13.0f * getJoulesStored(stack) / properties.capacity);
+		return (int) Math.round(13.0f * getJoulesStored(stack) / getMaximumCapacity(stack));
 	}
 
 	@Override
 	public boolean isBarVisible(ItemStack stack) {
-		return getJoulesStored(stack) < properties.capacity;
+		return getJoulesStored(stack) < getMaximumCapacity(stack);
 	}
 
 	@Override

--- a/src/main/java/electrodynamics/common/item/gear/tools/electric/ItemMechanizedCrossbow.java
+++ b/src/main/java/electrodynamics/common/item/gear/tools/electric/ItemMechanizedCrossbow.java
@@ -152,19 +152,19 @@ public class ItemMechanizedCrossbow extends ProjectileWeaponItem implements IIte
 		items.add(empty);
 
 		ItemStack charged = new ItemStack(this);
-		IItemElectric.setEnergyStored(charged, properties.capacity);
+		IItemElectric.setEnergyStored(charged, getMaximumCapacity(charged));
 		items.add(charged);
 
 	}
 
 	@Override
 	public int getBarWidth(ItemStack stack) {
-		return (int) Math.round(13.0f * getJoulesStored(stack) / properties.capacity);
+		return (int) Math.round(13.0f * getJoulesStored(stack) / getMaximumCapacity(stack));
 	}
 
 	@Override
 	public boolean isBarVisible(ItemStack stack) {
-		return getJoulesStored(stack) < properties.capacity;
+		return getJoulesStored(stack) < getMaximumCapacity(stack);
 	}
 
 	@Override

--- a/src/main/java/electrodynamics/common/tile/machines/charger/GenericTileCharger.java
+++ b/src/main/java/electrodynamics/common/tile/machines/charger/GenericTileCharger.java
@@ -48,7 +48,7 @@ public abstract class GenericTileCharger extends GenericTile {
 			if (inventory.inputs() > 1) {
 				hasOvervolted = drainBatterySlots(inventory, electro);
 			}
-			double room = electricItem.getElectricProperties().capacity - electricItem.getJoulesStored(itemInput);
+			double room = electricItem.getMaximumCapacity(itemInput) - electricItem.getJoulesStored(itemInput);
 			if (electro.getJoulesStored() > 0 && !hasOvervolted && room > 0) {
 				double recieveVoltage = electricItem.getElectricProperties().receive.getVoltage();
 				double machineVoltage = electro.getVoltage();
@@ -60,7 +60,7 @@ public abstract class GenericTileCharger extends GenericTile {
 					electro.joules(electro.getJoulesStored() - electricItem.receivePower(itemInput, TransferPack.joulesVoltage(electro.getJoulesStored(), machineVoltage), false).getJoules());
 				} else {
 					float underVoltRatio = (float) ((float) machineVoltage / recieveVoltage);
-					float itemStoredRatio = (float) ((float) electricItem.getJoulesStored(itemInput) / electricItem.getElectricProperties().capacity);
+					float itemStoredRatio = (float) ((float) electricItem.getJoulesStored(itemInput) / electricItem.getMaximumCapacity(itemInput));
 
 					float x = Math.abs(itemStoredRatio / (itemStoredRatio - underVoltRatio + 0.00000001F/* ensures it's never zero */));
 					float reductionCoef = getRationalFunctionValue(x);
@@ -70,7 +70,7 @@ public abstract class GenericTileCharger extends GenericTile {
 						electro.joules(electro.getJoulesStored() - electricItem.receivePower(itemInput, TransferPack.joulesVoltage(electro.getJoulesStored() * reductionCoef, recieveVoltage), false).getJoules());
 					}
 				}
-				if (electricItem.getJoulesStored(itemInput) == electricItem.getElectricProperties().capacity && inventory.getItem(4).isEmpty()) {
+				if (electricItem.getJoulesStored(itemInput) == electricItem.getMaximumCapacity(itemInput) && inventory.getItem(4).isEmpty()) {
 					inventory.setItem(4, inventory.getItem(0).copy());
 					inventory.getItem(0).shrink(1);
 				}

--- a/src/main/java/electrodynamics/prefab/item/ItemElectric.java
+++ b/src/main/java/electrodynamics/prefab/item/ItemElectric.java
@@ -40,19 +40,19 @@ public class ItemElectric extends ItemElectrodynamics implements IItemElectric {
 		IItemElectric.setEnergyStored(empty, 0);
 		items.add(empty);
 		ItemStack charged = new ItemStack(this);
-		IItemElectric.setEnergyStored(charged, properties.capacity);
+		IItemElectric.setEnergyStored(charged, getMaximumCapacity(charged));
 		items.add(charged);
 
 	}
 
 	@Override
 	public int getBarWidth(ItemStack stack) {
-		return (int) Math.round(13.0f * getJoulesStored(stack) / properties.capacity);
+		return (int) Math.round(13.0f * getJoulesStored(stack) / getMaximumCapacity(stack));
 	}
 
 	@Override
 	public boolean isBarVisible(ItemStack stack) {
-		return getJoulesStored(stack) < properties.capacity;
+		return getJoulesStored(stack) < getMaximumCapacity(stack);
 	}
 
 	@Override


### PR DESCRIPTION
The capacity can now be changed by the current holding battery, just as long as both voltages (receiving and extraction) match. It's now also correctly handled from other angles, such as the charger or stacks' durability bars, by calling `IItemElectric#getMaximumCapacity` instead of accessing `ElectricItemProperties#capacity` directly.
(changes to `CreativeTabSupplier#addCreativeModeItems` are technically not needed and unecessary overhead, but its better to have consistency, i do think)

While this may not be immediately beneficial to the base mod, I do believe that addons looking to add other types of battery (same voltage as base mod, different capacities) would be helped.

This is on a different branch so as to not come packaged with the patches in the other PR, in case these changes turn out to be undesired.