### PR TITLE
Thermoelectric Manipulator Fix

### DIFF
--- a/src/main/java/electrodynamics/common/item/gear/tools/ItemPortableCylinder.java
+++ b/src/main/java/electrodynamics/common/item/gear/tools/ItemPortableCylinder.java
@@ -52,7 +52,7 @@ public class ItemPortableCylinder extends ItemVoltaic {
 					continue;
 				}
 				ItemStack temp = new ItemStack(this);
-				temp.getCapability(VoltaicCapabilities.CAPABILITY_GASHANDLER_ITEM).ifPresent(cap -> ((GasHandlerItemStack) cap).setGas(new GasStack(gas, MAX_GAS_CAPCITY, Gas.ROOM_TEMPERATURE, Gas.PRESSURE_AT_SEA_LEVEL)));
+				temp.getCapability(VoltaicCapabilities.CAPABILITY_GASHANDLER_ITEM).ifPresent(cap -> ((GasHandlerItemStack) cap).setGas(new GasStack(gas, MAX_GAS_CAPCITY, gas.getCondensationTemp() >= Gas.ROOM_TEMPERATURE ? gas.getCondensationTemp() + 1 : Gas.ROOM_TEMPERATURE, Gas.PRESSURE_AT_SEA_LEVEL)));
 				items.add(temp);
 
 			}

--- a/src/main/java/electrodynamics/common/tile/pipelines/gas/gastransformer/thermoelectricmanipulator/GenericTileThermoelectricManipulator.java
+++ b/src/main/java/electrodynamics/common/tile/pipelines/gas/gastransformer/thermoelectricmanipulator/GenericTileThermoelectricManipulator.java
@@ -7,7 +7,6 @@ import electrodynamics.common.inventory.container.tile.ContainerThermoelectricMa
 import electrodynamics.common.tile.pipelines.gas.gastransformer.GenericTileGasTransformer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
@@ -199,7 +198,7 @@ public abstract class GenericTileThermoelectricManipulator extends GenericTileGa
             return new ManipulatorStatusCheckWrapper(false, ElectrodynamicsBlockStates.ManipulatorHeatingStatus.OFF, false);
         }
 
-        evaporatedGas = VoltaicGases.MAPPED_GASSES.getOrDefault(BuiltInRegistries.FLUID.wrapAsHolder(inputTank.getFluid().getFluid()), VoltaicGases.EMPTY.get());
+        evaporatedGas = VoltaicGases.MAPPED_GASSES.getOrDefault(inputTank.getFluid().getFluid(), VoltaicGases.EMPTY.get());
 
         if (evaporatedGas.isEmpty()) {
             return new ManipulatorStatusCheckWrapper(false, ElectrodynamicsBlockStates.ManipulatorHeatingStatus.OFF, false);


### PR DESCRIPTION
The thermoelectric manipulator had a problem where it could not make fluids evaporate.
Looking at the code I found that the issue is that it wasn't findng the evaporated gas in the mapped gasses hashmap. I changed the index and it now returns the evaporated gas, making the check to work properly and the manipulator to work