### PR TITLE
Fix Crash

### DIFF
--- a/src/main/java/electrodynamics/common/tile/machines/quarry/TileQuarry.java
+++ b/src/main/java/electrodynamics/common/tile/machines/quarry/TileQuarry.java
@@ -593,7 +593,7 @@ public class TileQuarry extends GenericTile implements IPlayerStorable {
     // responsible for clearing initial obstructions from the mining area
     private void clearArea() {
 	ComponentElectrodynamic electro = getComponent(IComponentType.Electrodynamic);
-	setupPowerUsage.setValue(ElectrodynamicsConfig.INSTANCE.QUARRY_USAGE_PER_TICK);
+	setupPowerUsage.setValue(ElectrodynamicsConfig.INSTANCE.QUARRY_USAGE_PER_TICK.get());
 	isPowered.setValue(electro.getJoulesStored() >= setupPowerUsage.getValue());
 	if (hasCorners() && isPowered.getValue()) {
 	    Level world = getLevel();


### PR DESCRIPTION
Fix ClassCastException in TileQuarry.clearArea() - call .get() on config value , wich causes the Game to Crash when using the Quarry 