### PR TITLE
Fix Framed Blocks conflict when other mods are present

### DIFF
--- a/src/main/java/electrodynamics/common/block/BlockFrame.java
+++ b/src/main/java/electrodynamics/common/block/BlockFrame.java
@@ -36,6 +36,7 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import voltaic.common.block.states.VoltaicBlockStates;
+import voltaic.common.block.states.VoltaicMaterials;
 
 public class BlockFrame extends BaseEntityBlock {
 
@@ -46,7 +47,7 @@ public class BlockFrame extends BaseEntityBlock {
     private final int type;
 
     public BlockFrame(int type) {
-        super(Blocks.IRON_BLOCK.properties().strength(3.5F).sound(SoundType.METAL).noOcclusion().requiresCorrectToolForDrops());
+        super(VoltaicMaterials.metal().strength(3.5F).sound(SoundType.METAL).noOcclusion().requiresCorrectToolForDrops());
         registerDefaultState(stateDefinition.any().setValue(ElectrodynamicsBlockStates.QUARRY_FRAME_DECAY, Boolean.FALSE).setValue(VoltaicBlockStates.WATERLOGGED, false).setValue(VoltaicBlockStates.FACING, Direction.NORTH));
         this.type = type;
     }

--- a/src/main/java/electrodynamics/common/block/BlockLogisticalManager.java
+++ b/src/main/java/electrodynamics/common/block/BlockLogisticalManager.java
@@ -21,6 +21,7 @@ import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import voltaic.common.block.connect.AbstractConnectBlock;
 import voltaic.common.block.connect.EnumConnectType;
+import voltaic.common.block.states.VoltaicMaterials;
 import voltaic.prefab.block.GenericEntityBlockWaterloggable;
 import voltaic.prefab.tile.types.IConnectTile;
 import voltaic.prefab.utilities.BlockEntityUtils;
@@ -40,7 +41,7 @@ public class BlockLogisticalManager extends GenericEntityBlockWaterloggable {
 
 
     public BlockLogisticalManager() {
-        super(Blocks.IRON_BLOCK.properties().strength(3.5F).sound(SoundType.METAL).noOcclusion().requiresCorrectToolForDrops());
+        super(VoltaicMaterials.metal().strength(3.5F).sound(SoundType.METAL).noOcclusion().requiresCorrectToolForDrops());
         generateBoundingBoxes(3);
     }
 

--- a/src/main/java/electrodynamics/common/block/connect/BlockFluidPipe.java
+++ b/src/main/java/electrodynamics/common/block/connect/BlockFluidPipe.java
@@ -17,6 +17,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import voltaic.api.network.cable.type.IFluidPipe;
 import voltaic.common.block.connect.AbstractRefreshingConnectBlock;
 import voltaic.common.block.connect.EnumConnectType;
+import voltaic.common.block.states.VoltaicMaterials;
 import voltaic.common.network.utils.FluidUtilities;
 
 public class BlockFluidPipe extends AbstractRefreshingConnectBlock<GenericTileFluidPipe> {
@@ -26,7 +27,7 @@ public class BlockFluidPipe extends AbstractRefreshingConnectBlock<GenericTileFl
     public final IFluidPipe pipe;
 
     public BlockFluidPipe(IFluidPipe pipe) {
-        super(Blocks.IRON_BLOCK.properties().sound(SoundType.METAL).strength(0.15f).dynamicShape().noOcclusion(), 3);
+        super(VoltaicMaterials.metal().sound(SoundType.METAL).strength(0.15f).dynamicShape().noOcclusion(), 3);
         this.pipe = pipe;
         PIPESET.add(this);
     }

--- a/src/main/java/electrodynamics/common/block/subtype/SubtypeGasPipe.java
+++ b/src/main/java/electrodynamics/common/block/subtype/SubtypeGasPipe.java
@@ -10,15 +10,16 @@ import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
 import voltaic.api.ISubtype;
 import voltaic.api.gas.Gas;
 import voltaic.api.network.cable.type.IGasPipe;
+import voltaic.common.block.states.VoltaicMaterials;
 
 public enum SubtypeGasPipe implements ISubtype, IGasPipe {
 
     /*
      * UNINSULATED
      */
-    UNINSULATEDCOPPER(PipeMaterial.COPPER, InsulationMaterial.NONE, 10000, 2.5, Blocks.IRON_BLOCK.properties(), SoundType.METAL), //
-    UNINSULATEDSTEEL(PipeMaterial.STEEL, InsulationMaterial.NONE, 30000, 2.5, Blocks.IRON_BLOCK.properties(), SoundType.METAL), //
-    UNINSULATEDPLASTIC(PipeMaterial.HDPE, InsulationMaterial.NONE, 1000, 2.5, Blocks.IRON_BLOCK.properties(), SoundType.STONE);//
+    UNINSULATEDCOPPER(PipeMaterial.COPPER, InsulationMaterial.NONE, 10000, 2.5, VoltaicMaterials.metal(), SoundType.METAL), //
+    UNINSULATEDSTEEL(PipeMaterial.STEEL, InsulationMaterial.NONE, 30000, 2.5, VoltaicMaterials.metal(), SoundType.METAL), //
+    UNINSULATEDPLASTIC(PipeMaterial.HDPE, InsulationMaterial.NONE, 1000, 2.5, VoltaicMaterials.metal(), SoundType.STONE);//
 
     /*
      * CERAMIC INSULATED

--- a/src/main/java/electrodynamics/common/block/subtype/SubtypeResourceBlock.java
+++ b/src/main/java/electrodynamics/common/block/subtype/SubtypeResourceBlock.java
@@ -13,21 +13,22 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
 import voltaic.api.ISubtype;
+import voltaic.common.block.states.VoltaicMaterials;
 import voltaic.common.tags.VoltaicTags;
 
 public enum SubtypeResourceBlock implements ISubtype {
-    tin(2.0f, 3.0f, Blocks.IRON_BLOCK.properties(), SoundType.METAL, 1, VoltaicTags.Items.STORAGE_BLOCK_TIN, VoltaicTags.Blocks.STORAGE_BLOCK_TIN, VoltaicTags.Items.INGOT_TIN, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.tin)),
-    lead(2.0f, 3.0f, Blocks.IRON_BLOCK.properties(), SoundType.METAL, 2, VoltaicTags.Items.STORAGE_BLOCK_LEAD, VoltaicTags.Blocks.STORAGE_BLOCK_LEAD, VoltaicTags.Items.INGOT_LEAD, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.lead)),
-    silver(2.0f, 3.0f, Blocks.IRON_BLOCK.properties(), SoundType.METAL, 2, VoltaicTags.Items.STORAGE_BLOCK_SILVER, VoltaicTags.Blocks.STORAGE_BLOCK_SILVER, VoltaicTags.Items.INGOT_SILVER, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.silver)),
-    bronze(2.0f, 3.0f, Blocks.IRON_BLOCK.properties(), SoundType.METAL, 1, VoltaicTags.Items.STORAGE_BLOCK_BRONZE, VoltaicTags.Blocks.STORAGE_BLOCK_BRONZE, VoltaicTags.Items.INGOT_BRONZE, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.bronze)),
-    steel(2.0f, 3.0f, Blocks.IRON_BLOCK.properties(), SoundType.METAL, 2, VoltaicTags.Items.STORAGE_BLOCK_STEEL, VoltaicTags.Blocks.STORAGE_BLOCK_STEEL, VoltaicTags.Items.INGOT_STEEL, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.steel)),
-    aluminum(2.0f, 3.0f, Blocks.IRON_BLOCK.properties(), SoundType.METAL, 2, VoltaicTags.Items.STORAGE_BLOCK_ALUMINUM, VoltaicTags.Blocks.STORAGE_BLOCK_ALUMINUM, VoltaicTags.Items.INGOT_ALUMINUM, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.aluminum)),
-    chromium(2.0f, 3.0f, Blocks.IRON_BLOCK.properties(), SoundType.METAL, 3, VoltaicTags.Items.STORAGE_BLOCK_CHROMIUM, VoltaicTags.Blocks.STORAGE_BLOCK_CHROMIUM, VoltaicTags.Items.INGOT_CHROMIUM, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.chromium)),
-    stainlesssteel(2.0f, 3.0f, Blocks.IRON_BLOCK.properties(), SoundType.METAL, 2, VoltaicTags.Items.STORAGE_BLOCK_STAINLESSSTEEL, VoltaicTags.Blocks.STORAGE_BLOCK_STAINLESSSTEEL, VoltaicTags.Items.INGOT_STAINLESSSTEEL, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.stainlesssteel)),
-    vanadiumsteel(2.0f, 3.0f, Blocks.IRON_BLOCK.properties(), SoundType.METAL, 2, VoltaicTags.Items.STORAGE_BLOCK_VANADIUMSTEEL, VoltaicTags.Blocks.STORAGE_BLOCK_VANADIUMSTEEL, VoltaicTags.Items.INGOT_VANADIUMSTEEL, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.vanadiumsteel)),
-    hslasteel(2.0f, 3.0f, Blocks.IRON_BLOCK.properties(), SoundType.METAL, 3, VoltaicTags.Items.STORAGE_BLOCK_HSLASTEEL, VoltaicTags.Blocks.STORAGE_BLOCK_HSLASTEEL, VoltaicTags.Items.INGOT_HSLASTEEL, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.hslasteel)),
-    titanium(2.0f, 3.0f, Blocks.IRON_BLOCK.properties(), SoundType.METAL, 3, VoltaicTags.Items.STORAGE_BLOCK_TITANIUM, VoltaicTags.Blocks.STORAGE_BLOCK_TITANIUM, VoltaicTags.Items.INGOT_TITANIUM, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.titanium)),
-    titaniumcarbide(2.0f, 3.0f, Blocks.IRON_BLOCK.properties(), SoundType.METAL, 3, VoltaicTags.Items.STORAGE_BLOCK_TITANIUMCARBIDE, VoltaicTags.Blocks.STORAGE_BLOCK_TITANIUMCARBIDE, VoltaicTags.Items.INGOT_TITANIUMCARBIDE, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.titaniumcarbide));
+    tin(2.0f, 3.0f, VoltaicMaterials.metal(), SoundType.METAL, 1, VoltaicTags.Items.STORAGE_BLOCK_TIN, VoltaicTags.Blocks.STORAGE_BLOCK_TIN, VoltaicTags.Items.INGOT_TIN, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.tin)),
+    lead(2.0f, 3.0f, VoltaicMaterials.metal(), SoundType.METAL, 2, VoltaicTags.Items.STORAGE_BLOCK_LEAD, VoltaicTags.Blocks.STORAGE_BLOCK_LEAD, VoltaicTags.Items.INGOT_LEAD, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.lead)),
+    silver(2.0f, 3.0f, VoltaicMaterials.metal(), SoundType.METAL, 2, VoltaicTags.Items.STORAGE_BLOCK_SILVER, VoltaicTags.Blocks.STORAGE_BLOCK_SILVER, VoltaicTags.Items.INGOT_SILVER, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.silver)),
+    bronze(2.0f, 3.0f, VoltaicMaterials.metal(), SoundType.METAL, 1, VoltaicTags.Items.STORAGE_BLOCK_BRONZE, VoltaicTags.Blocks.STORAGE_BLOCK_BRONZE, VoltaicTags.Items.INGOT_BRONZE, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.bronze)),
+    steel(2.0f, 3.0f, VoltaicMaterials.metal(), SoundType.METAL, 2, VoltaicTags.Items.STORAGE_BLOCK_STEEL, VoltaicTags.Blocks.STORAGE_BLOCK_STEEL, VoltaicTags.Items.INGOT_STEEL, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.steel)),
+    aluminum(2.0f, 3.0f, VoltaicMaterials.metal(), SoundType.METAL, 2, VoltaicTags.Items.STORAGE_BLOCK_ALUMINUM, VoltaicTags.Blocks.STORAGE_BLOCK_ALUMINUM, VoltaicTags.Items.INGOT_ALUMINUM, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.aluminum)),
+    chromium(2.0f, 3.0f, VoltaicMaterials.metal(), SoundType.METAL, 3, VoltaicTags.Items.STORAGE_BLOCK_CHROMIUM, VoltaicTags.Blocks.STORAGE_BLOCK_CHROMIUM, VoltaicTags.Items.INGOT_CHROMIUM, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.chromium)),
+    stainlesssteel(2.0f, 3.0f, VoltaicMaterials.metal(), SoundType.METAL, 2, VoltaicTags.Items.STORAGE_BLOCK_STAINLESSSTEEL, VoltaicTags.Blocks.STORAGE_BLOCK_STAINLESSSTEEL, VoltaicTags.Items.INGOT_STAINLESSSTEEL, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.stainlesssteel)),
+    vanadiumsteel(2.0f, 3.0f, VoltaicMaterials.metal(), SoundType.METAL, 2, VoltaicTags.Items.STORAGE_BLOCK_VANADIUMSTEEL, VoltaicTags.Blocks.STORAGE_BLOCK_VANADIUMSTEEL, VoltaicTags.Items.INGOT_VANADIUMSTEEL, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.vanadiumsteel)),
+    hslasteel(2.0f, 3.0f, VoltaicMaterials.metal(), SoundType.METAL, 3, VoltaicTags.Items.STORAGE_BLOCK_HSLASTEEL, VoltaicTags.Blocks.STORAGE_BLOCK_HSLASTEEL, VoltaicTags.Items.INGOT_HSLASTEEL, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.hslasteel)),
+    titanium(2.0f, 3.0f, VoltaicMaterials.metal(), SoundType.METAL, 3, VoltaicTags.Items.STORAGE_BLOCK_TITANIUM, VoltaicTags.Blocks.STORAGE_BLOCK_TITANIUM, VoltaicTags.Items.INGOT_TITANIUM, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.titanium)),
+    titaniumcarbide(2.0f, 3.0f, VoltaicMaterials.metal(), SoundType.METAL, 3, VoltaicTags.Items.STORAGE_BLOCK_TITANIUMCARBIDE, VoltaicTags.Blocks.STORAGE_BLOCK_TITANIUMCARBIDE, VoltaicTags.Items.INGOT_TITANIUMCARBIDE, () -> ElectrodynamicsItems.ITEMS_INGOT.getValue(SubtypeIngot.titaniumcarbide));
 
     private float hardness;
     private float resistance;

--- a/src/main/java/electrodynamics/registers/ElectrodynamicsBlocks.java
+++ b/src/main/java/electrodynamics/registers/ElectrodynamicsBlocks.java
@@ -44,6 +44,7 @@ import voltaic.api.tile.IMachine;
 import voltaic.common.block.BlockCustomGlass;
 import voltaic.common.block.BlockMachine;
 import voltaic.common.block.connect.BlockScaffold;
+import voltaic.common.block.states.VoltaicMaterials;
 import voltaic.common.block.voxelshapes.VoxelShapeProvider;
 import voltaic.prefab.block.GenericMachineBlock;
 
@@ -120,7 +121,7 @@ public class ElectrodynamicsBlocks {
     public static final DeferredHolder<Block, BlockGasTransformerAddonTank> BLOCK_COMPRESSOR_ADDONTANK = BLOCKS.register("compressoraddontank", BlockGasTransformerAddonTank::new);
     public static final DeferredHolder<Block, BlockThermoelectricManipulator> BLOCK_THERMOELECTRICMANIPULATOR = BLOCKS.register("thermoelectricmanipulator", BlockThermoelectricManipulator::new);
     public static final DeferredHolder<Block, BlockAdvancedThermoelectricManipulator> BLOCK_ADVANCED_THERMOELECTRICMANIPULATOR = BLOCKS.register("advancedthermoelectricmanipulator", BlockAdvancedThermoelectricManipulator::new);
-    public static final DeferredHolder<Block, BlockScaffold> BLOCK_STEELSCAFFOLDING = BLOCKS.register("steelscaffold", () -> new BlockScaffold(Blocks.IRON_BLOCK.properties().requiresCorrectToolForDrops().strength(2.0F, 3.0F).sound(SoundType.METAL).noOcclusion()));
+    public static final DeferredHolder<Block, BlockScaffold> BLOCK_STEELSCAFFOLDING = BLOCKS.register("steelscaffold", () -> new BlockScaffold(VoltaicMaterials.metal().requiresCorrectToolForDrops().strength(2.0F, 3.0F).sound(SoundType.METAL).noOcclusion()));
     public static final DeferredHolder<Block, BlockChemicalReactorExtra> BLOCK_CHEMICALREACTOREXTRA_MIDDLE = BLOCKS.register("chemicalreactorextramiddle", () -> new BlockChemicalReactorExtra(BlockChemicalReactorExtra.Location.MIDDLE));
     public static final DeferredHolder<Block, BlockChemicalReactorExtra> BLOCK_CHEMICALREACTOREXTRA_TOP = BLOCKS.register("chemicalreactorextratop", () -> new BlockChemicalReactorExtra(BlockChemicalReactorExtra.Location.TOP));
 


### PR DESCRIPTION
When installed alongside Bad Packets, CraftedCore, and Create, any block that is set up in its registration using aFullCopy(Blocks.IRON_BLOCK) definition from any other mod is unable to be used as a texture for a Framed Block from the Framed Blocks mod if Voltaic or any of the other mods are installed. It also seems to affect glass and TNT.

I have fixed this by changing the super(Blocks.IRON_BLOCK) as well as the GLASS, TNT, and WHITE_WOOL entries to use the VoltaicMaterials.materialName() methods instead. This fixes the issue. It doesn't look like Modular Forcefields uses the super(Blocks.NAME) anywhere so I have not submitted a fix for it.